### PR TITLE
✨ feat: add success message for quote sent for signature

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -333,6 +333,7 @@
             },
             "messages": {
                 "sendSignatureError": "Failed to send quote for signature",
+                "sendSignatureSuccess": "Quote sent for signature successfully",
                 "invoiceCreated": "Invoice created successfully from quote",
                 "invoiceCreateError": "Failed to create invoice from quote"
             }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -333,6 +333,7 @@
             },
             "messages": {
                 "sendSignatureError": "Échec de l'envoi du devis pour signature",
+                "sendSignatureSuccess": "Devis envoyé pour signature avec succès",
                 "invoiceCreated": "Facture créée avec succès à partir du devis",
                 "invoiceCreateError": "Échec de la création de la facture à partir du devis"
             }

--- a/frontend/src/pages/(app)/quotes/_components/quote-list.tsx
+++ b/frontend/src/pages/(app)/quotes/_components/quote-list.tsx
@@ -107,7 +107,7 @@ export const QuoteList = forwardRef<QuoteListHandle, QuoteListProps>(
                         return
                     }
 
-                    toast.success(data.message)
+                    toast.success(t("quotes.list.messages.sendSignatureSuccess"))
                     mutate()
                 })
                 .catch((error) => {

--- a/frontend/src/pages/(auth)/signup.tsx
+++ b/frontend/src/pages/(auth)/signup.tsx
@@ -74,7 +74,7 @@ export default function SignupPage() {
 
     useEffect(() => {
         if (data && !error) {
-            toast.success(data.message || t("auth.signup.messages.accountCreated"))
+            toast.success(t("auth.signup.messages.accountCreated"))
             setTimeout(() => {
                 navigate("/login")
             }, 1000)


### PR DESCRIPTION
This pull request introduces improvements to localization and toast messaging in the frontend. The most notable changes include adding a new localized message for successful quote signature in both English and French, and updating toast success messages to use translation keys directly for better consistency and maintainability.

### Localization Updates:
* Added the `sendSignatureSuccess` message to the English localization file (`frontend/src/locales/en/translation.json`) and the French localization file (`frontend/src/locales/fr/translation.json`). This message is used to indicate successful sending of a quote for signature. [[1]](diffhunk://#diff-a6916c1006782695d827d314f36c505fdfd8c99dfff19036f0d4ce039f626819R336) [[2]](diffhunk://#diff-7835583c693a89af7d2396f3d183820faaa0eb59f7622643e89b36bd81b47d86R336)

### Toast Messaging Improvements:
* Updated the success toast in `quote-list.tsx` to use the newly added `sendSignatureSuccess` translation key instead of relying on the `data.message` property. This ensures consistent messaging. (`frontend/src/pages/(app)/quotes/_components/quote-list.tsx`)
* Simplified the success toast in `signup.tsx` to directly use the `accountCreated` translation key, removing the fallback to `data.message`. This improves code clarity and ensures translation consistency. (`frontend/src/pages/(auth)/signup.tsx`)