### PR TITLE
fix/puppeteer pdf generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,20 @@ FROM nginx:alpine
 
 RUN apk add --no-cache nodejs npm
 
+RUN apk add --no-cache \
+    chromium \
+    nss \
+    freetype \
+    harfbuzz \
+    ttf-freefont \
+    chromium-chromedriver \
+    bash \
+    dumb-init \
+    && rm -rf /var/cache/apk/*
+
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+
 COPY --from=frontend-builder /app/frontend/dist /usr/share/nginx/html
 
 COPY --from=backend-builder /app/dist /usr/share/nginx/backend

--- a/backend/src/models/invoices/invoices.service.ts
+++ b/backend/src/models/invoices/invoices.service.ts
@@ -242,7 +242,11 @@ export class InvoicesService {
             notes: invoice.notes ?? '',
         });
 
-        const browser = await puppeteer.launch({ headless: true });
+        const browser = await puppeteer.launch({
+            headless: true,
+            executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || '/usr/bin/chromium-browser',
+            args: ['--no-sandbox', '--disable-setuid-sandbox'],
+        });
         const page = await browser.newPage();
         await page.setContent(html, { waitUntil: 'networkidle0' });
 

--- a/backend/src/models/quotes/quotes.service.ts
+++ b/backend/src/models/quotes/quotes.service.ts
@@ -258,7 +258,11 @@ export class QuotesService {
             },
         });
 
-        const browser = await puppeteer.launch({ headless: true });
+        const browser = await puppeteer.launch({
+            headless: true,
+            executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || '/usr/bin/chromium-browser',
+            args: ['--no-sandbox', '--disable-setuid-sandbox'],
+        });
         const page = await browser.newPage();
         await page.setContent(html, { waitUntil: 'networkidle0' });
 


### PR DESCRIPTION
This pull request introduces changes to enable Puppeteer to run in a containerized environment by configuring Chromium dependencies and updating Puppeteer launch options. The changes primarily focus on updating the Dockerfile and modifying Puppeteer usage in the backend services.

### Dockerfile Updates:
* Added installation of Chromium and related dependencies (e.g., `chromium-chromedriver`, `nss`, `freetype`) to support Puppeteer in the container. Also set the `PUPPETEER_EXECUTABLE_PATH` environment variable to point to the Chromium browser executable.

### Backend Service Updates:
* Updated Puppeteer launch options in `InvoicesService` to use the `PUPPETEER_EXECUTABLE_PATH` environment variable and added flags (`--no-sandbox`, `--disable-setuid-sandbox`) for better compatibility in containerized environments.
* Updated Puppeteer launch options in `QuotesService` with the same changes as in `InvoicesService` to ensure consistency and compatibility.