### PR TITLE
feat: use second color for the table note color

### DIFF
--- a/backend/src/models/invoices/invoices.service.ts
+++ b/backend/src/models/invoices/invoices.service.ts
@@ -244,6 +244,7 @@ export class InvoicesService {
             // Personnalisation via pdfConfig
             fontFamily: pdfConfig?.fontFamily ?? 'Inter',
             primaryColor: pdfConfig?.primaryColor ?? '#0ea5e9',
+            secondaryColor: pdfConfig?.secondaryColor ?? '#f3f4f6',
             padding: pdfConfig?.padding ?? 40,
             includeLogo: !!pdfConfig?.logoB64,
             logoUrl: pdfConfig?.logoB64 ?? '',
@@ -268,11 +269,19 @@ export class InvoicesService {
             notes: invoice.notes ?? '',
         });
 
-        const browser = await puppeteer.launch({
-            headless: true,
-            executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || '/usr/bin/chromium-browser',
-            args: ['--no-sandbox', '--disable-setuid-sandbox'],
-        });
+        let browser: puppeteer.Browser;
+        if (!process.env.PUPPETEER_EXECUTABLE_PATH) {
+            browser = await puppeteer.launch({
+                headless: true,
+                args: ['--no-sandbox', '--disable-setuid-sandbox'],
+            })
+        } else {
+            browser = await puppeteer.launch({
+                headless: true,
+                executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
+                args: ['--no-sandbox', '--disable-setuid-sandbox'],
+            });
+        }
         const page = await browser.newPage();
         await page.setContent(html, { waitUntil: 'networkidle0' });
 

--- a/backend/src/models/invoices/templates/base.template.ts
+++ b/backend/src/models/invoices/templates/base.template.ts
@@ -12,9 +12,9 @@ export const baseTemplate = `
         .client-info { margin-bottom: 30px; }
         table { width: 100%; border-collapse: collapse; margin: 20px 0; }
         th, td { padding: 12px; text-align: left; border-bottom: 1px solid #ddd; }
-        th { background-color: #f8f9fa; font-weight: bold; }
-        .total-row { font-weight: bold; background-color: #f8f9fa; }
-        .notes { margin-top: 30px; padding: 20px; background-color: #f8f9fa; border-radius: 4px; }
+        th { background-color: {{secondaryColor}}; font-weight: bold; }
+        .total-row { font-weight: bold; background-color: {{secondaryColor}}; }
+        .notes { margin-top: 30px; padding: 20px; background-color: {{secondaryColor}}; border-radius: 4px; }
         .logo { max-height: 80px; margin-bottom: 10px; }
     </style>
 </head>

--- a/backend/src/models/quotes/quotes.service.ts
+++ b/backend/src/models/quotes/quotes.service.ts
@@ -273,11 +273,19 @@ export class QuotesService {
             },
         });
 
-        const browser = await puppeteer.launch({
-            headless: true,
-            executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || '/usr/bin/chromium-browser',
-            args: ['--no-sandbox', '--disable-setuid-sandbox'],
-        });
+        let browser: puppeteer.Browser;
+        if (!process.env.PUPPETEER_EXECUTABLE_PATH) {
+            browser = await puppeteer.launch({
+                headless: true,
+                args: ['--no-sandbox', '--disable-setuid-sandbox'],
+            })
+        } else {
+            browser = await puppeteer.launch({
+                headless: true,
+                executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
+                args: ['--no-sandbox', '--disable-setuid-sandbox'],
+            });
+        }
         const page = await browser.newPage();
         await page.setContent(html, { waitUntil: 'networkidle0' });
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1027,7 +1027,8 @@
             "colors": {
                 "title": "Colors",
                 "description": "Brand colors and theme",
-                "primaryColor": "Primary Color"
+                "primaryColor": "Primary Color",
+                "secondaryColor": "Secondary Color"
             },
             "logo": {
                 "title": "Logo",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1027,7 +1027,8 @@
             "colors": {
                 "title": "Couleurs",
                 "description": "Couleurs de marque et thème",
-                "primaryColor": "Couleur principale"
+                "primaryColor": "Couleur principale",
+                "secondaryColor": "Couleur secondaire"
             },
             "logo": {
                 "title": "Logo",

--- a/frontend/src/pages/(app)/settings/_components/pdf.settings.tsx
+++ b/frontend/src/pages/(app)/settings/_components/pdf.settings.tsx
@@ -31,9 +31,9 @@ const defaultInvoiceTemplate = `<!DOCTYPE html>
         .client-info { margin-bottom: 30px; }
         table { width: 100%; border-collapse: collapse; margin: 20px 0; }
         th, td { padding: 12px; text-align: left; border-bottom: 1px solid #ddd; }
-        th { background-color: #f8f9fa; font-weight: bold; }
-        .total-row { font-weight: bold; background-color: #f8f9fa; }
-        .notes { margin-top: 30px; padding: 20px; background-color: #f8f9fa; border-radius: 4px; }
+        th { background-color: {{secondaryColor}}; font-weight: bold; }
+        .total-row { font-weight: bold; background-color: {{secondaryColor}}; }
+        .notes { margin-top: 30px; padding: 20px; background-color: {{secondaryColor}}; border-radius: 4px; }
         .logo { max-height: 80px; margin-bottom: 10px; }
     </style>
 </head>
@@ -458,6 +458,23 @@ export default function PDFTemplatesSettings() {
                                                     <Input
                                                         value={settings.primaryColor}
                                                         onChange={(e) => setSettings((prev) => ({ ...prev, primaryColor: e.target.value }))}
+                                                        className="flex-1"
+                                                    />
+                                                </div>
+                                            </div>
+                                            <div className="space-y-2">
+                                                <Label htmlFor="primary-color">{t("settings.pdfTemplates.colors.secondaryColor")}</Label>
+                                                <div className="flex items-center space-x-2">
+                                                    <input
+                                                        type="color"
+                                                        id="primary-color"
+                                                        value={settings.secondaryColor}
+                                                        onChange={(e) => setSettings((prev) => ({ ...prev, secondaryColor: e.target.value }))}
+                                                        className="w-12 h-10 rounded border border-input"
+                                                    />
+                                                    <Input
+                                                        value={settings.secondaryColor}
+                                                        onChange={(e) => setSettings((prev) => ({ ...prev, secondaryColor: e.target.value }))}
                                                         className="flex-1"
                                                     />
                                                 </div>


### PR DESCRIPTION
This pull request introduces support for a new `secondaryColor` configuration in both the backend and frontend, enhancing customization options for PDF templates. Additionally, it refactors Puppeteer browser initialization for improved environment compatibility.

### Backend Changes

* **Added `secondaryColor` Configuration**: Introduced a new `secondaryColor` field in the `InvoicesService` to allow customization of secondary colors in PDF generation. (`backend/src/models/invoices/invoices.service.ts`, [backend/src/models/invoices/invoices.service.tsR247](diffhunk://#diff-d6efcb35719c600444a43bd030a8f01dec2e37de4ccc3dc3c5a2b4bbfdcc610cR247))
* **Refactored Puppeteer Initialization**: Updated Puppeteer browser launch logic in both `InvoicesService` and `QuotesService` to handle cases where `PUPPETEER_EXECUTABLE_PATH` is not set, ensuring compatibility across environments. (`backend/src/models/invoices/invoices.service.ts`, [[1]](diffhunk://#diff-d6efcb35719c600444a43bd030a8f01dec2e37de4ccc3dc3c5a2b4bbfdcc610cL271-R284); `backend/src/models/quotes/quotes.service.ts`, [[2]](diffhunk://#diff-e0e26074dd96304b93c737f800f0bf3611e8100202b3c47b8e00546abda9a4edL276-R288)

### Frontend Changes

* **Template Updates for `secondaryColor`**: Updated the default invoice template and PDF settings template to use the new `secondaryColor` variable for table headers, total rows, and notes background styling. (`frontend/src/pages/(app)/settings/_components/pdf.settings.tsx`, [[1]](diffhunk://#diff-fa3eb4472e85bbec525dafac1806369f0ea884ec9b6c87340fb90e93c3a81c50L34-R36) [[2]](diffhunk://#diff-fa3eb4472e85bbec525dafac1806369f0ea884ec9b6c87340fb90e93c3a81c50R465-R481)
* **Localization Enhancements**: Added translations for `secondaryColor` in both English and French locales. (`frontend/src/locales/en/translation.json`, [[1]](diffhunk://#diff-a6916c1006782695d827d314f36c505fdfd8c99dfff19036f0d4ce039f626819L1030-R1031); `frontend/src/locales/fr/translation.json`, [[2]](diffhunk://#diff-7835583c693a89af7d2396f3d183820faaa0eb59f7622643e89b36bd81b47d86L1030-R1031)