### PR TITLE
✨ feat: add country field to company and client details in invoice and quote templates

### DIFF
--- a/backend/src/models/invoices/templates/base.template.ts
+++ b/backend/src/models/invoices/templates/base.template.ts
@@ -27,6 +27,7 @@ export const baseTemplate = `
             <h1>{{company.name}}</h1>
             <p>{{company.address}}<br>
             {{company.city}}, {{company.zip}}<br>
+            {{company.country}}<br>
             {{company.email}} | {{company.phone}}</p>
         </div>
         <div class="invoice-info">
@@ -41,6 +42,7 @@ export const baseTemplate = `
         <p>{{client.name}}<br>
         {{client.address}}<br>
         {{client.city}}, {{client.zip}}<br>
+        {{client.country}}<br>
         {{client.email}}</p>
     </div>
     <table>

--- a/backend/src/models/quotes/templates/base.template.ts
+++ b/backend/src/models/quotes/templates/base.template.ts
@@ -27,6 +27,7 @@ export const baseTemplate = `
             <h1>{{company.name}}</h1>
             <p>{{company.address}}<br>
             {{company.city}}, {{company.zip}}<br>
+            {{company.country}}<br>
             {{company.email}} | {{company.phone}}</p>
         </div>
         <div class="quote-info">
@@ -41,6 +42,7 @@ export const baseTemplate = `
         <p>{{client.name}}<br>
         {{client.address}}<br>
         {{client.city}}, {{client.zip}}<br>
+        {{client.country}}<br>
         {{client.email}}</p>
     </div>
     <table>


### PR DESCRIPTION
This pull request updates the invoice and quote templates to include the `country` field for both the company and client sections. These changes ensure that the templates display more complete address information.

### Template Updates for Address Information:

* [`backend/src/models/invoices/templates/base.template.ts`](diffhunk://#diff-d93b99cce6f8d6f8ebb195577cc5d71886926491208fb6bc9d2143264d06dac1R30): Added `{{company.country}}` and `{{client.country}}` fields to display the country for the company and client in the invoice template. [[1]](diffhunk://#diff-d93b99cce6f8d6f8ebb195577cc5d71886926491208fb6bc9d2143264d06dac1R30) [[2]](diffhunk://#diff-d93b99cce6f8d6f8ebb195577cc5d71886926491208fb6bc9d2143264d06dac1R45)
* [`backend/src/models/quotes/templates/base.template.ts`](diffhunk://#diff-30e15c2843bf1f87455fd818042ebaa7f1838a1b483736dc198aaff1556d1401R30): Added `{{company.country}}` and `{{client.country}}` fields to display the country for the company and client in the quote template. [[1]](diffhunk://#diff-30e15c2843bf1f87455fd818042ebaa7f1838a1b483736dc198aaff1556d1401R30) [[2]](diffhunk://#diff-30e15c2843bf1f87455fd818042ebaa7f1838a1b483736dc198aaff1556d1401R45)