### PR TITLE
feat: implement custom quote invoice number pattern

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -190,24 +190,26 @@ enum Currency {
 }
 
 model Company {
-  id             String         @id @default(cuid())
-  name           String
-  description    String
-  currency       Currency       @default(EUR)
-  legalId        String
-  foundedAt      DateTime
-  VAT            String
-  address        String
-  postalCode     String
-  city           String
-  country        String
-  phone          String
-  email          String
-  pDFConfigId    String         @unique
-  pdfConfig      PDFConfig      @relation(fields: [pDFConfigId], references: [id])
-  Quote          Quote[]
-  Invoice        Invoice[]
-  emailTemplates MailTemplate[]
+  id                  String         @id @default(cuid())
+  name                String
+  description         String
+  currency            Currency       @default(EUR)
+  legalId             String
+  foundedAt           DateTime
+  VAT                 String
+  address             String
+  postalCode          String
+  city                String
+  country             String
+  phone               String
+  email               String
+  quoteNumberFormat   String         @default("Q-{year}-{number:4}") // Ex: "Q-2025-0001"
+  invoiceNumberFormat String         @default("INV-{year}-{number:4}") // Ex: "INV-2025-0001"
+  pDFConfigId         String         @unique
+  pdfConfig           PDFConfig      @relation(fields: [pDFConfigId], references: [id])
+  Quote               Quote[]
+  Invoice             Invoice[]
+  emailTemplates      MailTemplate[]
 }
 
 model PDFConfig {
@@ -286,7 +288,7 @@ enum QuoteStatus {
 
 model Quote {
   id         String      @id @default(uuid())
-  number     String      @unique // Ex: "Q-2025-0001"
+  number     Int         @default(autoincrement())
   title      String?
   client     Client      @relation(fields: [clientId], references: [id])
   clientId   String
@@ -329,7 +331,7 @@ enum InvoiceStatus {
 
 model Invoice {
   id            String        @id @default(uuid())
-  number        String        @unique // Ex: "INV-2025-0001"
+  number        Int           @default(autoincrement())
   quote         Quote?        @relation(fields: [quoteId], references: [id])
   quoteId       String?
   client        Client        @relation(fields: [clientId], references: [id]) // Client receiving the invoice

--- a/backend/src/models/company/dto/company.dto.ts
+++ b/backend/src/models/company/dto/company.dto.ts
@@ -39,4 +39,6 @@ export class EditCompanyDto {
     phone: string
     email: string
     pdfConfig: PDFConfig
+    quoteNumberFormat: string
+    invoiceNumberFormat: string
 }

--- a/backend/src/models/invoices/invoices.service.ts
+++ b/backend/src/models/invoices/invoices.service.ts
@@ -13,8 +13,7 @@ import { finance } from '@fin.cx/einvoice/dist_ts/plugins';
 export class InvoicesService {
     constructor(private readonly prisma: PrismaService) { }
 
-    private formatPattern(pattern: string, number: number): string {
-        const date = new Date();
+    private formatPattern(pattern: string, number: number, date: Date = new Date()): string {
         return pattern.replace(/\{(\w+)(?::(\d+))?\}/g, (_, key, padding) => {
             let value: number | string;
 
@@ -68,7 +67,7 @@ export class InvoicesService {
 
         const returnedInvoices = invoices.map(quote => ({
             ...quote,
-            number: this.formatPattern(quote.company.invoiceNumberFormat, quote.number)
+            number: this.formatPattern(quote.company.invoiceNumberFormat, quote.number, quote.createdAt),
         }));
 
         const totalInvoices = await this.prisma.invoice.count();
@@ -316,7 +315,7 @@ export class InvoicesService {
         const companyFoundedDate = new Date(invRec.company.foundedAt || new Date())
         const clientFoundedDate = new Date(invRec.client.foundedAt || new Date());
 
-        inv.id = this.formatPattern(invRec.company.invoiceNumberFormat, invRec.number);
+        inv.id = this.formatPattern(invRec.company.invoiceNumberFormat, invRec.number, invRec.createdAt);
         inv.issueDate = new Date(invRec.createdAt.toISOString().split('T')[0]);
         inv.currency = invRec.company.currency as finance.TCurrency || 'EUR';
 

--- a/backend/src/models/invoices/invoices.service.ts
+++ b/backend/src/models/invoices/invoices.service.ts
@@ -32,7 +32,7 @@ export class InvoicesService {
                     value = number;
                     break;
                 default:
-                    throw new Error(`Unknown key: ${key}`);
+                    return key; // If the key is not recognized, return it as is
             }
 
             const padLength = padding !== undefined

--- a/backend/src/models/invoices/invoices.service.ts
+++ b/backend/src/models/invoices/invoices.service.ts
@@ -13,28 +13,36 @@ import { finance } from '@fin.cx/einvoice/dist_ts/plugins';
 export class InvoicesService {
     constructor(private readonly prisma: PrismaService) { }
 
-    private async getNextInvoiceNumber() {
-        const currentYear = new Date().getFullYear();
+    private formatPattern(pattern: string, number: number): string {
+        const date = new Date();
+        return pattern.replace(/\{(\w+)(?::(\d+))?\}/g, (_, key, padding) => {
+            let value: number | string;
 
-        const lastInvoice = await this.prisma.invoice.findFirst({
-            where: {
-                createdAt: {
-                    gte: new Date(`${currentYear}-01-01T00:00:00Z`),
-                    lt: new Date(`${currentYear + 1}-01-01T00:00:00Z`),
-                },
-            },
-            orderBy: {
-                number: 'desc',
-            },
+            switch (key) {
+                case "year":
+                    value = date.getFullYear();
+                    break;
+                case "month":
+                    value = date.getMonth() + 1;
+                    break;
+                case "day":
+                    value = date.getDate();
+                    break;
+                case "number":
+                    value = number;
+                    break;
+                default:
+                    throw new Error(`Unknown key: ${key}`);
+            }
+
+            const padLength = padding !== undefined
+                ? parseInt(padding, 10)
+                : key === "number"
+                    ? 4
+                    : 0;
+
+            return value.toString().padStart(padLength, "0");
         });
-
-        let nextIndex = 1;
-        if (lastInvoice) {
-            const parts = lastInvoice.number.split('-');
-            nextIndex = parseInt(parts[2]) + 1;
-        }
-        const paddedIndex = String(nextIndex).padStart(4, '0');
-        return `INV-${currentYear}-${paddedIndex}`;
     }
 
     async getInvoices(page: string) {
@@ -58,9 +66,14 @@ export class InvoicesService {
             },
         });
 
+        const returnedInvoices = invoices.map(quote => ({
+            ...quote,
+            number: this.formatPattern(quote.company.invoiceNumberFormat, quote.number)
+        }));
+
         const totalInvoices = await this.prisma.invoice.count();
 
-        return { pageCount: Math.ceil(totalInvoices / pageSize), invoices };
+        return { pageCount: Math.ceil(totalInvoices / pageSize), invoices: returnedInvoices };
     }
 
     async createInvoice(body: CreateInvoiceDto) {
@@ -82,7 +95,6 @@ export class InvoicesService {
             data: {
                 ...data,
                 currency: body.currency || client.currency || company.currency,
-                number: await this.getNextInvoiceNumber(),
                 companyId: company.id, // reuse the already fetched company object
                 totalHT: items.reduce((sum, item) => sum + (item.quantity * item.unitPrice), 0),
                 totalVAT: items.reduce((sum, item) => sum +
@@ -304,7 +316,7 @@ export class InvoicesService {
         const companyFoundedDate = new Date(invRec.company.foundedAt || new Date())
         const clientFoundedDate = new Date(invRec.client.foundedAt || new Date());
 
-        inv.id = invRec.number;
+        inv.id = this.formatPattern(invRec.company.invoiceNumberFormat, invRec.number);
         inv.issueDate = new Date(invRec.createdAt.toISOString().split('T')[0]);
         inv.currency = invRec.company.currency as finance.TCurrency || 'EUR';
 

--- a/backend/src/models/quotes/quotes.service.ts
+++ b/backend/src/models/quotes/quotes.service.ts
@@ -30,7 +30,7 @@ export class QuotesService {
                     value = number;
                     break;
                 default:
-                    throw new Error(`Unknown key: ${key}`);
+                    return key;
             }
 
             const padLength = padding !== undefined

--- a/backend/src/models/quotes/quotes.service.ts
+++ b/backend/src/models/quotes/quotes.service.ts
@@ -11,28 +11,36 @@ import { baseTemplate } from './templates/base.template';
 export class QuotesService {
     constructor(private readonly prisma: PrismaService) { }
 
-    private async getNextQuoteNumber() {
-        const currentYear = new Date().getFullYear();
+    private formatPattern(pattern: string, number: number): string {
+        const date = new Date();
+        return pattern.replace(/\{(\w+)(?::(\d+))?\}/g, (_, key, padding) => {
+            let value: number | string;
 
-        const lastQuote = await this.prisma.quote.findFirst({
-            where: {
-                createdAt: {
-                    gte: new Date(`${currentYear}-01-01T00:00:00Z`),
-                    lt: new Date(`${currentYear + 1}-01-01T00:00:00Z`),
-                },
-            },
-            orderBy: {
-                number: 'desc',
-            },
+            switch (key) {
+                case "year":
+                    value = date.getFullYear();
+                    break;
+                case "month":
+                    value = date.getMonth() + 1;
+                    break;
+                case "day":
+                    value = date.getDate();
+                    break;
+                case "number":
+                    value = number;
+                    break;
+                default:
+                    throw new Error(`Unknown key: ${key}`);
+            }
+
+            const padLength = padding !== undefined
+                ? parseInt(padding, 10)
+                : key === "number"
+                    ? 4
+                    : 0;
+
+            return value.toString().padStart(padLength, "0");
         });
-
-        let nextIndex = 1;
-        if (lastQuote) {
-            const parts = lastQuote.number.split('-');
-            nextIndex = parseInt(parts[2]) + 1;
-        }
-        const paddedIndex = String(nextIndex).padStart(4, '0');
-        return `Q-${currentYear}-${paddedIndex}`;
     }
 
     async getQuotes(page: string) {
@@ -56,9 +64,14 @@ export class QuotesService {
             },
         });
 
+        const returnedQuotes = quotes.map(quote => ({
+            ...quote,
+            number: this.formatPattern(quote.company.quoteNumberFormat, quote.number)
+        }));
+
         const totalQuotes = await this.prisma.quote.count();
 
-        return { pageCount: Math.ceil(totalQuotes / pageSize), quotes };
+        return { pageCount: Math.ceil(totalQuotes / pageSize), quotes: returnedQuotes };
     }
 
     async searchQuotes(query: string) {
@@ -75,7 +88,6 @@ export class QuotesService {
             where: {
                 isActive: true,
                 OR: [
-                    { number: { contains: query } },
                     { title: { contains: query } },
                     { client: { name: { contains: query } } },
                 ],
@@ -110,7 +122,6 @@ export class QuotesService {
         return this.prisma.quote.create({
             data: {
                 ...data,
-                number: await this.getNextQuoteNumber(),
                 companyId: company.id,
                 currency: body.currency || client.currency || company.currency,
                 totalHT: items.reduce((sum, item) => sum + (item.quantity * item.unitPrice), 0),

--- a/backend/src/models/quotes/quotes.service.ts
+++ b/backend/src/models/quotes/quotes.service.ts
@@ -11,8 +11,7 @@ import { baseTemplate } from './templates/base.template';
 export class QuotesService {
     constructor(private readonly prisma: PrismaService) { }
 
-    private formatPattern(pattern: string, number: number): string {
-        const date = new Date();
+    private formatPattern(pattern: string, number: number, date: Date = new Date()): string {
         return pattern.replace(/\{(\w+)(?::(\d+))?\}/g, (_, key, padding) => {
             let value: number | string;
 
@@ -66,7 +65,7 @@ export class QuotesService {
 
         const returnedQuotes = quotes.map(quote => ({
             ...quote,
-            number: this.formatPattern(quote.company.quoteNumberFormat, quote.number)
+            number: this.formatPattern(quote.company.quoteNumberFormat, quote.number, quote.createdAt),
         }));
 
         const totalQuotes = await this.prisma.quote.count();

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -790,6 +790,10 @@
                 "title": "Contact Information",
                 "description": "How clients can reach your company"
             },
+            "numberFormats": {
+                "title": "Number Formats",
+                "description": "Customize the number formats for quotes and invoices"
+            },
             "form": {
                 "company": {
                     "label": "Company Name",
@@ -891,6 +895,26 @@
                     "errors": {
                         "required": "Email is required",
                         "format": "Email format is invalid"
+                    }
+                },
+                "quoteNumberFormat": {
+                    "label": "Quote Number Format",
+                    "placeholder": "Enter quote number format (e.g., Q-{year}-{number})",
+                    "description": "Format for quote numbers",
+                    "errors": {
+                        "required": "Quote number format is required",
+                        "maxLength": "Quote number format must be less than 100 characters",
+                        "format": "Quote number format is invalid. Use {year}, {month}, {day}, {number} with optional padding (e.g., {number:4})"
+                    }
+                },
+                "invoiceNumberFormat": {
+                    "label": "Invoice Number Format",
+                    "placeholder": "Enter invoice number format (e.g., INV-{year}-{number})",
+                    "description": "Format for invoice numbers",
+                    "errors": {
+                        "required": "Invoice number format is required",
+                        "maxLength": "Invoice number format must be less than 100 characters",
+                        "format": "Invoice number format is invalid. Use {year}, {month}, {day}, {number} with optional padding (e.g., {number:4})"
                     }
                 },
                 "saving": "Saving...",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -790,6 +790,10 @@
                 "title": "Informations de contact",
                 "description": "Comment les clients peuvent contacter votre entreprise"
             },
+            "numberFormats": {
+                "title": "Formats de numéros",
+                "description": "Personnalisez les formats de numéros pour les devis et factures"
+            },
             "form": {
                 "company": {
                     "label": "Nom de l'entreprise",
@@ -891,6 +895,26 @@
                     "errors": {
                         "required": "L'email est requis",
                         "format": "Le format de l'email est invalide"
+                    }
+                },
+                "quoteNumberFormat": {
+                    "label": "Format du numéro de devis",
+                    "placeholder": "Entrez le format du numéro de devis (ex: QUOTE-{year}-{number})",
+                    "description": "Format pour les numéros de devis",
+                    "errors": {
+                        "required": "Le format du numéro de devis est requis",
+                        "maxLength": "Le format du numéro de devis doit faire moins de 100 caractères",
+                        "format": "Format invalide. Utilisez {year}, {month}, {day}, {number} avec un padding optionnel (ex: {number:4})"
+                    }
+                },
+                "invoiceNumberFormat": {
+                    "label": "Format du numéro de facture",
+                    "placeholder": "Entrez le format du numéro de facture (ex: INVOICE-{year}-{number})",
+                    "description": "Format pour les numéros de facture",
+                    "errors": {
+                        "required": "Le format du numéro de facture est requis",
+                        "maxLength": "Le format du numéro de facture doit faire moins de 100 caractères",
+                        "format": "Format invalide. Utilisez {year}, {month}, {day}, {number} avec un padding optionnel (ex: {number:4})"
                     }
                 },
                 "saving": "Enregistrement...",

--- a/frontend/src/pages/(app)/settings/_components/company.settings.tsx
+++ b/frontend/src/pages/(app)/settings/_components/company.settings.tsx
@@ -19,7 +19,43 @@ export default function CompanySettings() {
     const { t } = useTranslation()
     const navigate = useNavigate()
 
-    // Move schema inside component to access t function
+    const validateNumberFormat = (pattern: string): boolean => {
+        const patternRegex = /\{(\w+)(?::(\d+))?\}/g
+        const validKeys = ["year", "month", "day", "number"]
+        const requiredKeys = ["number"]
+
+        let match
+        const matches = []
+
+        while ((match = patternRegex.exec(pattern)) !== null) {
+            matches.push(match)
+        }
+
+        for (const key of requiredKeys) {
+            if (!matches.some(m => m[1] === key)) {
+                return false
+            }
+        }
+
+        for (const match of matches) {
+            const key = match[1]
+            const padding = match[2]
+
+            if (!validKeys.includes(key)) {
+                return false
+            }
+
+            if (padding !== undefined) {
+                const paddingNum = Number.parseInt(padding, 10)
+                if (isNaN(paddingNum) || paddingNum < 0 || paddingNum > 20) {
+                    return false
+                }
+            }
+        }
+
+        return true
+    }
+
     const companySchema = z.object({
         name: z
             .string({ required_error: t("settings.company.form.company.errors.required") })
@@ -60,6 +96,18 @@ export default function CompanySettings() {
             .refine((val) => {
                 return z.string().email().safeParse(val).success
             }, t("settings.company.form.email.errors.format")),
+        quoteNumberFormat: z.string()
+            .min(1, t("settings.company.form.quoteNumberFormat.errors.required"))
+            .max(100, t("settings.company.form.quoteNumberFormat.errors.maxLength"))
+            .refine((val) => {
+                return validateNumberFormat(val)
+            }, t("settings.company.form.quoteNumberFormat.errors.format")),
+        invoiceNumberFormat: z.string()
+            .min(1, t("settings.company.form.invoiceNumberFormat.errors.required"))
+            .max(100, t("settings.company.form.invoiceNumberFormat.errors.maxLength"))
+            .refine((val) => {
+                return validateNumberFormat(val)
+            }, t("settings.company.form.invoiceNumberFormat.errors.format")),
     })
 
     const { data } = useGet<Company>("/api/company/info")
@@ -327,6 +375,45 @@ export default function CompanySettings() {
                                                 <Input type="email" placeholder={t("settings.company.form.email.placeholder")} {...field} />
                                             </FormControl>
                                             <FormDescription>{t("settings.company.form.email.description")}</FormDescription>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>{t("settings.company.numberFormats.title")}</CardTitle>
+                            <CardDescription>{t("settings.company.numberFormats.description")}</CardDescription>
+                        </CardHeader>
+                        <CardContent className="space-y-6">
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                                <FormField
+                                    control={form.control}
+                                    name="quoteNumberFormat"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel required>{t("settings.company.form.quoteNumberFormat.label")}</FormLabel>
+                                            <FormControl>
+                                                <Input placeholder={t("settings.company.form.quoteNumberFormat.placeholder")} {...field} />
+                                            </FormControl>
+                                            <FormDescription>{t("settings.company.form.quoteNumberFormat.description")}</FormDescription>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name="invoiceNumberFormat"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel required>{t("settings.company.form.invoiceNumberFormat.label")}</FormLabel>
+                                            <FormControl>
+                                                <Input placeholder={t("settings.company.form.invoiceNumberFormat.placeholder")} {...field} />
+                                            </FormControl>
+                                            <FormDescription>{t("settings.company.form.invoiceNumberFormat.description")}</FormDescription>
                                             <FormMessage />
                                         </FormItem>
                                     )}

--- a/frontend/src/types/company.ts
+++ b/frontend/src/types/company.ts
@@ -11,4 +11,6 @@ export interface Company {
     country: string
     phone: string
     email: string
+    quoteNumberFormat: string
+    invoiceNumberFormat: string
 }


### PR DESCRIPTION
This pull request introduces customizable number formats for quotes and invoices, replacing the previous static numbering system. The changes span backend schema updates, service logic adjustments, and frontend enhancements to support this functionality.

### Backend Changes

**Database Schema Updates:**
* Added `quoteNumberFormat` and `invoiceNumberFormat` fields to the `Company` model, with default patterns for generating numbers (e.g., `Q-{year}-{number:4}` for quotes). (`backend/prisma/schema.prisma`, [backend/prisma/schema.prismaR206-R207](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR206-R207))
* Changed the `number` field in `Quote` and `Invoice` models from `String` to `Int`, now using an auto-incrementing integer. (`backend/prisma/schema.prisma`, [[1]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfL289-R291) [[2]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfL332-R334)

**Service Logic Updates:**
* Replaced the old `getNextQuoteNumber` and `getNextInvoiceNumber` methods with a new `formatPattern` method for generating numbers based on customizable patterns. (`backend/src/models/invoices/invoices.service.ts`, [[1]](diffhunk://#diff-d6efcb35719c600444a43bd030a8f01dec2e37de4ccc3dc3c5a2b4bbfdcc610cL16-R44); `backend/src/models/quotes/quotes.service.ts`, [[2]](diffhunk://#diff-e0e26074dd96304b93c737f800f0bf3611e8100202b3c47b8e00546abda9a4edL14-R42)
* Updated `getInvoices` and `getQuotes` methods to format numbers dynamically using the company's specified pattern. (`backend/src/models/invoices/invoices.service.ts`, [[1]](diffhunk://#diff-d6efcb35719c600444a43bd030a8f01dec2e37de4ccc3dc3c5a2b4bbfdcc610cR68-R75); `backend/src/models/quotes/quotes.service.ts`, [[2]](diffhunk://#diff-e0e26074dd96304b93c737f800f0bf3611e8100202b3c47b8e00546abda9a4edR66-R73)

---

### Frontend Changes

**User Interface Enhancements:**
* Added a new "Number Formats" section in the company settings page, allowing users to configure `quoteNumberFormat` and `invoiceNumberFormat`. (`frontend/src/pages/(app)/settings/_components/company.settings.tsx`, [frontend/src/pages/(app)/settings/_components/company.settings.tsxR386-R424](diffhunk://#diff-210870cab32a730121e1f5fb960b37d49c8b1be0522999f652d4e78f6fc5d667R386-R424))
* Implemented validation for number format patterns, ensuring correct syntax and required fields like `{number}`. (`frontend/src/pages/(app)/settings/_components/company.settings.tsx`, [[1]](diffhunk://#diff-210870cab32a730121e1f5fb960b37d49c8b1be0522999f652d4e78f6fc5d667L22-R58) [[2]](diffhunk://#diff-210870cab32a730121e1f5fb960b37d49c8b1be0522999f652d4e78f6fc5d667R99-R110)

**Localization:**
* Updated English and French translations to include labels, descriptions, and error messages for the new number format fields. (`frontend/src/locales/en/translation.json`, [[1]](diffhunk://#diff-a6916c1006782695d827d314f36c505fdfd8c99dfff19036f0d4ce039f626819R793-R796) [[2]](diffhunk://#diff-a6916c1006782695d827d314f36c505fdfd8c99dfff19036f0d4ce039f626819R900-R919); `frontend/src/locales/fr/translation.json`, [[3]](diffhunk://#diff-7835583c693a89af7d2396f3d183820faaa0eb59f7622643e89b36bd81b47d86R793-R796) [[4]](diffhunk://#diff-7835583c693a89af7d2396f3d183820faaa0eb59f7622643e89b36bd81b47d86R900-R919)

---

### Type Updates
* Extended the `Company` type to include `quoteNumberFormat` and `invoiceNumberFormat` fields. (`frontend/src/types/company.ts`, [frontend/src/types/company.tsR14-R15](diffhunk://#diff-c9ec186bd666bcac03d18c6611e237b75dfa456ab795b5929646af51a7416c00R14-R15))