### PR TITLE
feat: select the starting quote invoice number

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -190,26 +190,28 @@ enum Currency {
 }
 
 model Company {
-  id                  String         @id @default(cuid())
-  name                String
-  description         String
-  currency            Currency       @default(EUR)
-  legalId             String
-  foundedAt           DateTime
-  VAT                 String
-  address             String
-  postalCode          String
-  city                String
-  country             String
-  phone               String
-  email               String
-  quoteNumberFormat   String         @default("Q-{year}-{number:4}") // Ex: "Q-2025-0001"
-  invoiceNumberFormat String         @default("INV-{year}-{number:4}") // Ex: "INV-2025-0001"
-  pDFConfigId         String         @unique
-  pdfConfig           PDFConfig      @relation(fields: [pDFConfigId], references: [id])
-  Quote               Quote[]
-  Invoice             Invoice[]
-  emailTemplates      MailTemplate[]
+  id                    String         @id @default(cuid())
+  name                  String
+  description           String
+  currency              Currency       @default(EUR)
+  legalId               String
+  foundedAt             DateTime
+  VAT                   String
+  address               String
+  postalCode            String
+  city                  String
+  country               String
+  phone                 String
+  email                 String
+  quoteStartingNumber   Int            @default(1) // Starting number for quotes
+  quoteNumberFormat     String         @default("Q-{year}-{number:4}") // Ex: "Q-2025-0001"
+  invoiceStartingNumber Int            @default(1) // Starting number for invoices
+  invoiceNumberFormat   String         @default("INV-{year}-{number:4}") // Ex: "INV-2025-0001"
+  pDFConfigId           String         @unique
+  pdfConfig             PDFConfig      @relation(fields: [pDFConfigId], references: [id])
+  Quote                 Quote[]
+  Invoice               Invoice[]
+  emailTemplates        MailTemplate[]
 }
 
 model PDFConfig {

--- a/backend/src/models/company/dto/company.dto.ts
+++ b/backend/src/models/company/dto/company.dto.ts
@@ -39,6 +39,8 @@ export class EditCompanyDto {
     phone: string
     email: string
     pdfConfig: PDFConfig
+    quoteStartingNumber: number
     quoteNumberFormat: string
+    invoiceStartingNumber: number
     invoiceNumberFormat: string
 }

--- a/backend/src/models/quotes/quotes.service.ts
+++ b/backend/src/models/quotes/quotes.service.ts
@@ -67,9 +67,11 @@ export class QuotesService {
             },
         });
 
-        const returnedQuotes = quotes.map(quote => ({
-            ...quote,
-            number: this.formatPattern(quote.company.quoteNumberFormat, quote.number, quote.createdAt),
+        const returnedQuotes = await Promise.all(quotes.map(async (quote) => {
+            return {
+                ...quote,
+                number: await this.formatPattern(quote.company.quoteNumberFormat, quote.number, quote.createdAt),
+            }
         }));
 
         const totalQuotes = await this.prisma.quote.count();

--- a/backend/src/models/quotes/quotes.service.ts
+++ b/backend/src/models/quotes/quotes.service.ts
@@ -11,7 +11,11 @@ import { baseTemplate } from './templates/base.template';
 export class QuotesService {
     constructor(private readonly prisma: PrismaService) { }
 
-    private formatPattern(pattern: string, number: number, date: Date = new Date()): string {
+    private async formatPattern(pattern: string, number: number, date: Date = new Date()): Promise<string> {
+        const company = await this.prisma.company.findFirst();
+        if (!company) {
+            throw new BadRequestException('No company found. Please create a company first.');
+        }
         return pattern.replace(/\{(\w+)(?::(\d+))?\}/g, (_, key, padding) => {
             let value: number | string;
 
@@ -26,7 +30,7 @@ export class QuotesService {
                     value = date.getDate();
                     break;
                 case "number":
-                    value = number;
+                    value = number + company.quoteStartingNumber - 1; // Use the quote starting number from the company
                     break;
                 default:
                     return key;

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -897,6 +897,14 @@
                         "format": "Email format is invalid"
                     }
                 },
+                "quoteStartingNumber": {
+                    "label": "Quote Starting Number",
+                    "placeholder": "Enter starting number for quotes",
+                    "description": "Initial number for quote numbering",
+                    "errors": {
+                        "min": "Quote starting number must be at least 1"
+                    }
+                },
                 "quoteNumberFormat": {
                     "label": "Quote Number Format",
                     "placeholder": "Enter quote number format (e.g., Q-{year}-{number})",
@@ -905,6 +913,14 @@
                         "required": "Quote number format is required",
                         "maxLength": "Quote number format must be less than 100 characters",
                         "format": "Quote number format is invalid. Use {year}, {month}, {day}, {number} with optional padding (e.g., {number:4})"
+                    }
+                },
+                "invoiceStartingNumber": {
+                    "label": "Invoice Starting Number",
+                    "placeholder": "Enter starting number for invoices",
+                    "description": "Initial number for invoice numbering",
+                    "errors": {
+                        "min": "Invoice starting number must be at least 1"
                     }
                 },
                 "invoiceNumberFormat": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -897,6 +897,14 @@
                         "format": "Le format de l'email est invalide"
                     }
                 },
+                "quoteStartingNumber": {
+                    "label": "Numéro de départ des devis",
+                    "placeholder": "Saisir le numéro de départ des devis",
+                    "description": "Le numéro à partir duquel les devis commenceront",
+                    "errors": {
+                        "min": "Le numéro de départ des devis doit être d'au moins 1"
+                    }
+                },
                 "quoteNumberFormat": {
                     "label": "Format du numéro de devis",
                     "placeholder": "Entrez le format du numéro de devis (ex: QUOTE-{year}-{number})",
@@ -905,6 +913,14 @@
                         "required": "Le format du numéro de devis est requis",
                         "maxLength": "Le format du numéro de devis doit faire moins de 100 caractères",
                         "format": "Format invalide. Utilisez {year}, {month}, {day}, {number} avec un padding optionnel (ex: {number:4})"
+                    }
+                },
+                "invoiceStartingNumber": {
+                    "label": "Numéro de départ des factures",
+                    "placeholder": "Saisir le numéro de départ des factures",
+                    "description": "Le numéro à partir duquel les factures commenceront",
+                    "errors": {
+                        "min": "Le numéro de départ des factures doit être d'au moins 1"
                     }
                 },
                 "invoiceNumberFormat": {

--- a/frontend/src/pages/(app)/settings/_components/company.settings.tsx
+++ b/frontend/src/pages/(app)/settings/_components/company.settings.tsx
@@ -96,13 +96,17 @@ export default function CompanySettings() {
             .refine((val) => {
                 return z.string().email().safeParse(val).success
             }, t("settings.company.form.email.errors.format")),
-        quoteNumberFormat: z.string()
+        quoteStartingNumber: z.number().min(1, t("settings.company.form.quoteStartingNumber.errors.min")),
+        quoteNumberFormat: z
+            .string()
             .min(1, t("settings.company.form.quoteNumberFormat.errors.required"))
             .max(100, t("settings.company.form.quoteNumberFormat.errors.maxLength"))
             .refine((val) => {
                 return validateNumberFormat(val)
             }, t("settings.company.form.quoteNumberFormat.errors.format")),
-        invoiceNumberFormat: z.string()
+        invoiceStartingNumber: z.number().min(1, t("settings.company.form.invoiceStartingNumber.errors.min")),
+        invoiceNumberFormat: z
+            .string()
             .min(1, t("settings.company.form.invoiceNumberFormat.errors.required"))
             .max(100, t("settings.company.form.invoiceNumberFormat.errors.maxLength"))
             .refine((val) => {
@@ -389,35 +393,79 @@ export default function CompanySettings() {
                             <CardDescription>{t("settings.company.numberFormats.description")}</CardDescription>
                         </CardHeader>
                         <CardContent className="space-y-6">
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                                <FormField
-                                    control={form.control}
-                                    name="quoteNumberFormat"
-                                    render={({ field }) => (
-                                        <FormItem>
-                                            <FormLabel required>{t("settings.company.form.quoteNumberFormat.label")}</FormLabel>
-                                            <FormControl>
-                                                <Input placeholder={t("settings.company.form.quoteNumberFormat.placeholder")} {...field} />
-                                            </FormControl>
-                                            <FormDescription>{t("settings.company.form.quoteNumberFormat.description")}</FormDescription>
-                                            <FormMessage />
-                                        </FormItem>
-                                    )}
-                                />
-                                <FormField
-                                    control={form.control}
-                                    name="invoiceNumberFormat"
-                                    render={({ field }) => (
-                                        <FormItem>
-                                            <FormLabel required>{t("settings.company.form.invoiceNumberFormat.label")}</FormLabel>
-                                            <FormControl>
-                                                <Input placeholder={t("settings.company.form.invoiceNumberFormat.placeholder")} {...field} />
-                                            </FormControl>
-                                            <FormDescription>{t("settings.company.form.invoiceNumberFormat.description")}</FormDescription>
-                                            <FormMessage />
-                                        </FormItem>
-                                    )}
-                                />
+                            <div className="space-y-6">
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                                    <FormField
+                                        control={form.control}
+                                        name="quoteStartingNumber"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel required>{t("settings.company.form.quoteStartingNumber.label")}</FormLabel>
+                                                <FormControl>
+                                                    <Input
+                                                        type="number"
+                                                        placeholder={t("settings.company.form.quoteStartingNumber.placeholder")}
+                                                        {...field}
+                                                        onChange={(e) => field.onChange(Number(e.target.value))}
+                                                    />
+                                                </FormControl>
+                                                <FormDescription>{t("settings.company.form.quoteStartingNumber.description")}</FormDescription>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+                                    <FormField
+                                        control={form.control}
+                                        name="quoteNumberFormat"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel required>{t("settings.company.form.quoteNumberFormat.label")}</FormLabel>
+                                                <FormControl>
+                                                    <Input placeholder={t("settings.company.form.quoteNumberFormat.placeholder")} {...field} />
+                                                </FormControl>
+                                                <FormDescription>{t("settings.company.form.quoteNumberFormat.description")}</FormDescription>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+                                </div>
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                                    <FormField
+                                        control={form.control}
+                                        name="invoiceStartingNumber"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel required>{t("settings.company.form.invoiceStartingNumber.label")}</FormLabel>
+                                                <FormControl>
+                                                    <Input
+                                                        type="number"
+                                                        placeholder={t("settings.company.form.invoiceStartingNumber.placeholder")}
+                                                        {...field}
+                                                        onChange={(e) => field.onChange(Number(e.target.value))}
+                                                    />
+                                                </FormControl>
+                                                <FormDescription>
+                                                    {t("settings.company.form.invoiceStartingNumber.description")}
+                                                </FormDescription>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+                                    <FormField
+                                        control={form.control}
+                                        name="invoiceNumberFormat"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel required>{t("settings.company.form.invoiceNumberFormat.label")}</FormLabel>
+                                                <FormControl>
+                                                    <Input placeholder={t("settings.company.form.invoiceNumberFormat.placeholder")} {...field} />
+                                                </FormControl>
+                                                <FormDescription>{t("settings.company.form.invoiceNumberFormat.description")}</FormDescription>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+                                </div>
                             </div>
                         </CardContent>
                     </Card>

--- a/frontend/src/types/company.ts
+++ b/frontend/src/types/company.ts
@@ -11,6 +11,8 @@ export interface Company {
     country: string
     phone: string
     email: string
+    quoteStartingNumber: number
     quoteNumberFormat: string
+    invoiceStartingNumber: number
     invoiceNumberFormat: string
 }


### PR DESCRIPTION
This pull request introduces functionality to support customizable starting numbers for quotes and invoices, along with corresponding updates to the backend, frontend, and localization files. The changes ensure that quote and invoice numbering can start from user-defined values, improving flexibility for business requirements.

### Backend Updates

* **Database Schema Enhancements**: Added `quoteStartingNumber` and `invoiceStartingNumber` fields to the `Company` model in `schema.prisma`, both with a default value of 1. These fields define the starting numbers for quotes and invoices respectively.
* **DTO Updates**: Updated the `EditCompanyDto` class to include `quoteStartingNumber` and `invoiceStartingNumber` fields for data transfer.
* **Service Logic Adjustments**:
  - Modified `InvoicesService` and `QuotesService` to incorporate the `quoteStartingNumber` and `invoiceStartingNumber` fields into the numbering logic. This includes adjustments to the `formatPattern` method and related mappings. [[1]](diffhunk://#diff-d6efcb35719c600444a43bd030a8f01dec2e37de4ccc3dc3c5a2b4bbfdcc610cL16-R20) [[2]](diffhunk://#diff-d6efcb35719c600444a43bd030a8f01dec2e37de4ccc3dc3c5a2b4bbfdcc610cL31-R35) [[3]](diffhunk://#diff-d6efcb35719c600444a43bd030a8f01dec2e37de4ccc3dc3c5a2b4bbfdcc610cL68-R75) [[4]](diffhunk://#diff-d6efcb35719c600444a43bd030a8f01dec2e37de4ccc3dc3c5a2b4bbfdcc610cL318-R322) [[5]](diffhunk://#diff-e0e26074dd96304b93c737f800f0bf3611e8100202b3c47b8e00546abda9a4edL14-R18) [[6]](diffhunk://#diff-e0e26074dd96304b93c737f800f0bf3611e8100202b3c47b8e00546abda9a4edL29-R33) [[7]](diffhunk://#diff-e0e26074dd96304b93c737f800f0bf3611e8100202b3c47b8e00546abda9a4edL66-R74)

### Frontend Updates

* **Form Enhancements**:
  - Added input fields for `quoteStartingNumber` and `invoiceStartingNumber` in the company settings form, including validation to ensure values are at least 1. [[1]](diffhunk://#diff-210870cab32a730121e1f5fb960b37d49c8b1be0522999f652d4e78f6fc5d667L99-R109) [[2]](diffhunk://#diff-210870cab32a730121e1f5fb960b37d49c8b1be0522999f652d4e78f6fc5d667R396-R416) [[3]](diffhunk://#diff-210870cab32a730121e1f5fb960b37d49c8b1be0522999f652d4e78f6fc5d667R431-R453) [[4]](diffhunk://#diff-210870cab32a730121e1f5fb960b37d49c8b1be0522999f652d4e78f6fc5d667R469)
* **Type Updates**: Updated the `Company` interface to include `quoteStartingNumber` and `invoiceStartingNumber` fields.

### Localization Updates

* **English and French Translations**:
  - Added translations for `quoteStartingNumber` and `invoiceStartingNumber` fields, including labels, placeholders, descriptions, and error messages. [[1]](diffhunk://#diff-a6916c1006782695d827d314f36c505fdfd8c99dfff19036f0d4ce039f626819R900-R907) [[2]](diffhunk://#diff-a6916c1006782695d827d314f36c505fdfd8c99dfff19036f0d4ce039f626819R918-R925) [[3]](diffhunk://#diff-7835583c693a89af7d2396f3d183820faaa0eb59f7622643e89b36bd81b47d86R900-R907) [[4]](diffhunk://#diff-7835583c693a89af7d2396f3d183820faaa0eb59f7622643e89b36bd81b47d86R918-R925)