### PR TITLE
✨ feat: add date label to PDF configuration for improved invoice templates

### DIFF
--- a/backend/src/models/company/company.service.ts
+++ b/backend/src/models/company/company.service.ts
@@ -43,6 +43,7 @@ export class CompanyService {
             labels: {
                 billTo: existingCompany.pdfConfig.billTo,
                 description: existingCompany.pdfConfig.description,
+                date: existingCompany.pdfConfig.date,
                 dueDate: existingCompany.pdfConfig.dueDate,
                 grandTotal: existingCompany.pdfConfig.grandTotal,
                 invoice: existingCompany.pdfConfig.invoice,
@@ -81,6 +82,7 @@ export class CompanyService {
                 billTo: pdfConfig.labels.billTo,
                 description: pdfConfig.labels.description,
                 dueDate: pdfConfig.labels.dueDate,
+                date: pdfConfig.labels.date,
                 grandTotal: pdfConfig.labels.grandTotal,
                 invoice: pdfConfig.labels.invoice,
                 quantity: pdfConfig.labels.quantity,

--- a/backend/src/models/company/dto/company.dto.ts
+++ b/backend/src/models/company/dto/company.dto.ts
@@ -11,6 +11,7 @@ export interface PDFConfig {
         billTo: string
         description: string
         dueDate: string
+        date: string
         grandTotal: string
         invoice: string
         quantity: string


### PR DESCRIPTION
This pull request adds support for a new `date` field in the `PDFConfig` structure used by the `CompanyService`. The changes ensure that the `date` field is properly included in both the data model and the service logic for handling PDF configurations.

Changes related to the `date` field:

* [`backend/src/models/company/dto/company.dto.ts`](diffhunk://#diff-513409e03dea743c850d3211a74e687b83d8030c2e1f7961fafd5e0078d90597R14): Added the `date` field to the `PDFConfig` interface to include it in the data model.
* [`backend/src/models/company/company.service.ts`](diffhunk://#diff-2e1c913868738bab3acecd5245d3f07960264a0c7d0b54d4ba440639ea574d39R46): Updated the `labels` mapping in the `CompanyService` to include the `date` field when processing PDF configurations. [[1]](diffhunk://#diff-2e1c913868738bab3acecd5245d3f07960264a0c7d0b54d4ba440639ea574d39R46) [[2]](diffhunk://#diff-2e1c913868738bab3acecd5245d3f07960264a0c7d0b54d4ba440639ea574d39R85)…lates