### PR TITLE
feat: invert table text color

### DIFF
--- a/backend/src/models/invoices/invoices.service.ts
+++ b/backend/src/models/invoices/invoices.service.ts
@@ -13,6 +13,21 @@ import { finance } from '@fin.cx/einvoice/dist_ts/plugins';
 export class InvoicesService {
     constructor(private readonly prisma: PrismaService) { }
 
+    private getInvertColor(hex: string): string {
+        let cleanHex = hex.replace(/^#/, '');
+        if (cleanHex.length === 3) {
+            cleanHex = cleanHex.split('').map(c => c + c).join('');
+        }
+
+        const r = parseInt(cleanHex.slice(0, 2), 16);
+        const g = parseInt(cleanHex.slice(2, 4), 16);
+        const b = parseInt(cleanHex.slice(4, 6), 16);
+
+        const luminance = 0.299 * r + 0.587 * g + 0.114 * b;
+
+        return luminance > 186 ? '#000000' : '#ffffff';
+    }
+
     private async formatPattern(pattern: string, number: number, date: Date = new Date()): Promise<string> {
         const company = await this.prisma.company.findFirst();
         if (!company) {
@@ -256,10 +271,10 @@ export class InvoicesService {
             totalVAT: invoice.totalVAT.toFixed(2),
             totalTTC: invoice.totalTTC.toFixed(2),
 
-            // Personnalisation via pdfConfig
-            fontFamily: pdfConfig?.fontFamily ?? 'Inter',
-            primaryColor: pdfConfig?.primaryColor ?? '#0ea5e9',
-            secondaryColor: pdfConfig?.secondaryColor ?? '#f3f4f6',
+            fontFamily: pdfConfig.fontFamily ?? 'Inter',
+            primaryColor: pdfConfig.primaryColor ?? '#0ea5e9',
+            secondaryColor: pdfConfig.secondaryColor ?? '#f3f4f6',
+            tableTextColor: this.getInvertColor(pdfConfig.secondaryColor),
             padding: pdfConfig?.padding ?? 40,
             includeLogo: !!pdfConfig?.logoB64,
             logoUrl: pdfConfig?.logoB64 ?? '',

--- a/backend/src/models/invoices/templates/base.template.ts
+++ b/backend/src/models/invoices/templates/base.template.ts
@@ -12,9 +12,9 @@ export const baseTemplate = `
         .client-info { margin-bottom: 30px; }
         table { width: 100%; border-collapse: collapse; margin: 20px 0; }
         th, td { padding: 12px; text-align: left; border-bottom: 1px solid #ddd; }
-        th { background-color: {{secondaryColor}}; font-weight: bold; }
-        .total-row { font-weight: bold; background-color: {{secondaryColor}}; }
-        .notes { margin-top: 30px; padding: 20px; background-color: {{secondaryColor}}; border-radius: 4px; }
+        th { background-color: {{secondaryColor}}; font-weight: bold; color: {{tableTextColor}}; }
+        .total-row { font-weight: bold; background-color: {{secondaryColor}}; color: {{tableTextColor}}; }
+        .notes { margin-top: 30px; padding: 20px; background-color: {{secondaryColor}}; border-radius: 4px; color: {{tableTextColor}}; }
         .logo { max-height: 80px; margin-bottom: 10px; }
     </style>
 </head>

--- a/backend/src/models/quotes/quotes.service.ts
+++ b/backend/src/models/quotes/quotes.service.ts
@@ -46,6 +46,21 @@ export class QuotesService {
         });
     }
 
+    private getInvertColor(hex: string): string {
+        let cleanHex = hex.replace(/^#/, '');
+        if (cleanHex.length === 3) {
+            cleanHex = cleanHex.split('').map(c => c + c).join('');
+        }
+
+        const r = parseInt(cleanHex.slice(0, 2), 16);
+        const g = parseInt(cleanHex.slice(2, 4), 16);
+        const b = parseInt(cleanHex.slice(4, 6), 16);
+
+        const luminance = 0.299 * r + 0.587 * g + 0.114 * b;
+
+        return luminance > 186 ? '#000000' : '#ffffff';
+    }
+
     async getQuotes(page: string) {
         const pageNumber = parseInt(page, 10) || 1;
         const pageSize = 10;
@@ -272,6 +287,7 @@ export class QuotesService {
             padding: config.padding,
             primaryColor: config.primaryColor,
             secondaryColor: config.secondaryColor,
+            tableTextColor: this.getInvertColor(config.secondaryColor),
             includeLogo: config.includeLogo,
             logoB64: config.logoB64 ? `data:image/png;base64,${config.logoB64}` : undefined,
             labels: {

--- a/backend/src/models/quotes/templates/base.template.ts
+++ b/backend/src/models/quotes/templates/base.template.ts
@@ -12,8 +12,8 @@ export const baseTemplate = `
         .client-info { margin-bottom: 30px; }
         table { width: 100%; border-collapse: collapse; margin: 20px 0; }
         th, td { padding: 12px; text-align: left; border-bottom: 1px solid #ddd; }
-        th { background-color: #f0fdf4; font-weight: bold; }
-        .total-row { font-weight: bold; background-color: #f0fdf4; }
+        th { background-color: {{secondaryColor}}; font-weight: bold; color: {{tableTextColor}}; }
+        .total-row { font-weight: bold; background-color: {{secondaryColor}}; color: {{tableTextColor}}; }
         .validity { color: #dc2626; font-weight: bold; }
         .logo { max-height: 80px; margin-bottom: 10px; }
     </style>

--- a/frontend/src/pages/(app)/settings/_components/pdf.settings.tsx
+++ b/frontend/src/pages/(app)/settings/_components/pdf.settings.tsx
@@ -31,9 +31,9 @@ const defaultInvoiceTemplate = `<!DOCTYPE html>
         .client-info { margin-bottom: 30px; }
         table { width: 100%; border-collapse: collapse; margin: 20px 0; }
         th, td { padding: 12px; text-align: left; border-bottom: 1px solid #ddd; }
-        th { background-color: {{secondaryColor}}; font-weight: bold; }
-        .total-row { font-weight: bold; background-color: {{secondaryColor}}; }
-        .notes { margin-top: 30px; padding: 20px; background-color: {{secondaryColor}}; border-radius: 4px; }
+        th { background-color: {{secondaryColor}}; font-weight: bold; color: {{tableTextColor}}; }
+        .total-row { font-weight: bold; background-color: {{secondaryColor}}; color: {{tableTextColor}}; }
+        .notes { margin-top: 30px; padding: 20px; background-color: {{secondaryColor}}; border-radius: 4px; color: {{tableTextColor}}; }
         .logo { max-height: 80px; margin-bottom: 10px; }
     </style>
 </head>
@@ -123,8 +123,8 @@ const defaultQuoteTemplate = `
         .client-info { margin-bottom: 30px; }
         table { width: 100%; border-collapse: collapse; margin: 20px 0; }
         th, td { padding: 12px; text-align: left; border-bottom: 1px solid #ddd; }
-        th { background-color: #f0fdf4; font-weight: bold; }
-        .total-row { font-weight: bold; background-color: #f0fdf4; }
+        th { background-color: {{secondaryColor}}; font-weight: bold; color: {{tableTextColor}}; }
+        .total-row { font-weight: bold; background-color: {{secondaryColor}}; color: {{tableTextColor}}; }
         .validity { color: #dc2626; font-weight: bold; }
         .logo { max-height: 80px; margin-bottom: 10px; }
     </style>
@@ -227,6 +227,21 @@ export default function PDFTemplatesSettings() {
     const { data: companyTemplateSettings } = useGet<TemplateSettings>("/api/company/pdf-template")
     const { trigger: updateTemplateSettings, loading: updateTemplateSettingsLoading } =
         usePost<TemplateSettings>("/api/company/pdf-template")
+
+    function getInvertColor(hex: string): string {
+        let cleanHex = hex.replace(/^#/, '');
+        if (cleanHex.length === 3) {
+            cleanHex = cleanHex.split('').map(c => c + c).join('');
+        }
+
+        const r = parseInt(cleanHex.slice(0, 2), 16);
+        const g = parseInt(cleanHex.slice(2, 4), 16);
+        const b = parseInt(cleanHex.slice(4, 6), 16);
+
+        const luminance = 0.299 * r + 0.587 * g + 0.114 * b;
+
+        return luminance > 186 ? '#000000' : '#ffffff';
+    }
 
     const [settings, setSettings] = useState<TemplateSettings>({
         templateType: "invoice",
@@ -348,6 +363,7 @@ export default function PDFTemplatesSettings() {
             fontFamily: settings.fontFamily,
             primaryColor: settings.primaryColor,
             secondaryColor: settings.secondaryColor,
+            tableTextColor: getInvertColor(settings.secondaryColor),
             padding: settings.padding,
             includeLogo: settings.includeLogo,
             logoB64: settings.logoB64,


### PR DESCRIPTION
This pull request introduces a new utility function `getInvertColor` to dynamically determine text color based on background color luminance, ensuring better readability. It applies this function across invoice and quote templates in both backend and frontend codebases. The changes also enhance the styling of PDF templates by incorporating the computed `tableTextColor`.

### Backend Changes

#### Utility Function Addition:
* Added `getInvertColor` method in `InvoicesService` and `QuotesService` to calculate text color based on the luminance of the background color. [[1]](diffhunk://#diff-d6efcb35719c600444a43bd030a8f01dec2e37de4ccc3dc3c5a2b4bbfdcc610cR16-R30) [[2]](diffhunk://#diff-e0e26074dd96304b93c737f800f0bf3611e8100202b3c47b8e00546abda9a4edR49-R63)

#### Invoice and Quote Styling Updates:
* Updated `InvoicesService` and `QuotesService` to use `getInvertColor` for dynamically setting `tableTextColor` in PDF configurations. [[1]](diffhunk://#diff-d6efcb35719c600444a43bd030a8f01dec2e37de4ccc3dc3c5a2b4bbfdcc610cL259-R277) [[2]](diffhunk://#diff-e0e26074dd96304b93c737f800f0bf3611e8100202b3c47b8e00546abda9a4edR290)
* Modified invoice and quote templates to use `tableTextColor` for text color in table headers, total rows, and notes sections. [[1]](diffhunk://#diff-d93b99cce6f8d6f8ebb195577cc5d71886926491208fb6bc9d2143264d06dac1L15-R17) [[2]](diffhunk://#diff-30e15c2843bf1f87455fd818042ebaa7f1838a1b483736dc198aaff1556d1401L15-R16)

### Frontend Changes

#### Utility Function Addition:
* Added `getInvertColor` function in `PDFTemplatesSettings` to compute text color based on luminance for frontend PDF template settings.

#### Template Styling Updates:
* Updated default invoice and quote templates to use `tableTextColor` for improved text readability. [[1]](diffhunk://#diff-fa3eb4472e85bbec525dafac1806369f0ea884ec9b6c87340fb90e93c3a81c50L34-R36) [[2]](diffhunk://#diff-fa3eb4472e85bbec525dafac1806369f0ea884ec9b6c87340fb90e93c3a81c50L126-R127)
* Applied `getInvertColor` to dynamically set `tableTextColor` in PDF template settings based on `secondaryColor`.