### PR TITLE
🐛 fix: correct logoB64 property assignment in invoice and quote services

### DIFF
--- a/backend/src/models/invoices/invoices.service.ts
+++ b/backend/src/models/invoices/invoices.service.ts
@@ -283,7 +283,7 @@ export class InvoicesService {
             tableTextColor: this.getInvertColor(pdfConfig.secondaryColor),
             padding: pdfConfig?.padding ?? 40,
             includeLogo: !!pdfConfig?.logoB64,
-            logoUrl: pdfConfig?.logoB64 ?? '',
+            logoB64: pdfConfig?.logoB64 ?? '',
 
             noteExists: !!invoice.notes,
             notes: (invoice.notes || '').replace(/\n/g, '<br>'),

--- a/backend/src/models/quotes/quotes.service.ts
+++ b/backend/src/models/quotes/quotes.service.ts
@@ -291,7 +291,7 @@ export class QuotesService {
             secondaryColor: config.secondaryColor,
             tableTextColor: this.getInvertColor(config.secondaryColor),
             includeLogo: config.includeLogo,
-            logoB64: config.logoB64 ? `data:image/png;base64,${config.logoB64}` : undefined,
+            logoB64: config?.logoB64 ?? '',
             noteExists: !!quote.notes,
             notes: (quote.notes || '').replace(/\n/g, '<br>'),
             labels: {


### PR DESCRIPTION
This pull request makes adjustments to the handling of `logoB64` in the invoice and quote services to ensure consistent behavior when the `logoB64` property is undefined or empty. The changes simplify the logic and improve code readability.

Changes to `logoB64` handling:

* [`backend/src/models/invoices/invoices.service.ts`](diffhunk://#diff-d6efcb35719c600444a43bd030a8f01dec2e37de4ccc3dc3c5a2b4bbfdcc610cL286-R286): Updated the `logoB64` property in the `InvoicesService` to use a default empty string when `pdfConfig?.logoB64` is undefined, replacing the previous `logoUrl` property.
* [`backend/src/models/quotes/quotes.service.ts`](diffhunk://#diff-e0e26074dd96304b93c737f800f0bf3611e8100202b3c47b8e00546abda9a4edL294-R294): Simplified the `logoB64` property in the `QuotesService` to use a default empty string when `config?.logoB64` is undefined, removing the base64 prefix logic.