### PR TITLE
🐛 fix: remove LoginRequired decorator from getQuotePdf method

### DIFF
--- a/backend/src/models/quotes/quotes.controller.ts
+++ b/backend/src/models/quotes/quotes.controller.ts
@@ -21,7 +21,6 @@ export class QuotesController {
     }
 
     @Get(':id/pdf')
-    @LoginRequired()
     async getQuotePdf(@Param('id') id: string, @Res() res: Response) {
         if (id === 'undefined') return res.status(400).send('Invalid quote ID');
         const pdfBuffer = await this.quotesService.getQuotePdf(id);


### PR DESCRIPTION
This pull request removes the `@LoginRequired()` decorator from the `getQuotePdf` method in the `QuotesController` class. This change allows the method to be accessed without requiring user authentication.