### PR TITLE
feat: select date format

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "@types/pdfkit": "^0.14.0",
         "@types/stream-buffers": "^3.0.7",
         "bcrypt": "^6.0.0",
+        "date-fns": "^4.1.0",
         "handlebars": "^4.7.8",
         "nodemailer": "^7.0.3",
         "pdfkit": "^0.17.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,7 @@
     "@types/pdfkit": "^0.14.0",
     "@types/stream-buffers": "^3.0.7",
     "bcrypt": "^6.0.0",
+    "date-fns": "^4.1.0",
     "handlebars": "^4.7.8",
     "nodemailer": "^7.0.3",
     "pdfkit": "^0.17.1",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -211,7 +211,7 @@ model Company {
 
   invoicePDFFormat String @default("facturx") // Ex: 'pdf' | 'facturx' | 'zugferd' | 'xrechnung' | 'ubl' | 'cii'
 
-  dateFormat String @default("dd/mm/yyyy") // Date format for quotes and invoices
+  dateFormat String @default("dd/LL/yyyy") // Date format for quotes and invoices
 
   pDFConfigId    String         @unique
   pdfConfig      PDFConfig      @relation(fields: [pDFConfigId], references: [id])

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -211,6 +211,8 @@ model Company {
 
   invoicePDFFormat String @default("facturx") // Ex: 'pdf' | 'facturx' | 'zugferd' | 'xrechnung' | 'ubl' | 'cii'
 
+  dateFormat String @default("dd/mm/yyyy") // Date format for quotes and invoices
+
   pDFConfigId    String         @unique
   pdfConfig      PDFConfig      @relation(fields: [pDFConfigId], references: [id])
   Quote          Quote[]

--- a/backend/src/models/invoices/invoices.service.ts
+++ b/backend/src/models/invoices/invoices.service.ts
@@ -265,8 +265,8 @@ export class InvoicesService {
         const { pdfConfig } = invoice.company;
         const html = template({
             number: await this.formatPattern(invoice.company.invoiceNumberFormat, invoice.number, invoice.createdAt),
-            date: formatDate(invoice.createdAt),
-            dueDate: formatDate(invoice.dueDate),
+            date: formatDate(invoice.company, invoice.createdAt),
+            dueDate: formatDate(invoice.company, invoice.dueDate),
             company: invoice.company,
             client: invoice.client,
             currency: invoice.currency,

--- a/backend/src/models/quotes/quotes.service.ts
+++ b/backend/src/models/quotes/quotes.service.ts
@@ -7,6 +7,7 @@ import { CreateQuoteDto, EditQuotesDto } from './dto/quotes.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { baseTemplate } from './templates/base.template';
 import { format } from 'date-fns';
+import { formatDate } from 'src/utils/date';
 import { getPDF } from 'src/utils/pdf';
 
 @Injectable()
@@ -266,21 +267,10 @@ export class QuotesService {
         const templateHtml = baseTemplate;
         const template = Handlebars.compile(templateHtml);
 
-        const formatDate = (date: Date | null | undefined) => {
-            if (!date) return 'N/A';
-            const company = quote.company;
-            let dateFormat = company.dateFormat;
-            const allowedFormats = ['dd/mm/yyyy', 'mm/dd/yyyy', 'yyyy/mm/dd', 'dd.mm.yyyy', 'dd-mm-yyyy', 'yyyy-mm-dd', 'EEEE, dd MMM yyyy'];
-            if (!allowedFormats.includes(dateFormat)) {
-                dateFormat = 'dd/mm/yyyy'; // Default to dd/mm/yyyy if the format is not recognized
-            }
-            format(date, dateFormat);
-        };
-
         const html = template({
             number: await this.formatPattern(quote.company.quoteNumberFormat, quote.number, quote.createdAt),
-            date: formatDate(quote.createdAt),
-            validUntil: formatDate(quote.validUntil),
+            date: formatDate(quote.company, quote.createdAt),
+            validUntil: formatDate(quote.company, quote.validUntil),
             company: quote.company,
             client: quote.client,
             currency: quote.currency,

--- a/backend/src/utils/date.ts
+++ b/backend/src/utils/date.ts
@@ -2,21 +2,13 @@ import { Company, PrismaClient } from "@prisma/client";
 
 import { format } from "date-fns";
 
-export const formatDate = async (date?: Date | null, company?: Company | null) => {
+export const formatDate = (company: Company, date?: Date | null,) => {
     if (!date) return 'N/A';
 
-    if (!company) {
-        const prisma = new PrismaClient();
-        company = await prisma.company.findFirst();
-        if (!company) {
-            throw new Error('Company not found');
-        }
-    }
-
     let dateFormat = company.dateFormat;
-    const allowedFormats = ['dd/mm/yyyy', 'mm/dd/yyyy', 'yyyy/mm/dd', 'dd.mm.yyyy', 'dd-mm-yyyy', 'yyyy-mm-dd', 'EEEE, dd MMM yyyy'];
+    const allowedFormats = ['dd/LL/yyyy', 'LL/dd/yyyy', 'yyyy/LL/dd', 'dd.LL.yyyy', 'dd-LL-yyyy', 'yyyy-LL-dd', 'EEEE, dd MMM yyyy'];
     if (!allowedFormats.includes(dateFormat)) {
-        dateFormat = 'dd/mm/yyyy'; // Default to dd/mm/yyyy if the format is not recognized
+        dateFormat = 'dd/LL/yyyy'; // Default format if the stored format is invalid
     }
-    format(date, dateFormat);
+    return format(date, dateFormat);
 };

--- a/backend/src/utils/date.ts
+++ b/backend/src/utils/date.ts
@@ -1,0 +1,22 @@
+import { Company, PrismaClient } from "@prisma/client";
+
+import { format } from "date-fns";
+
+export const formatDate = async (date?: Date | null, company?: Company | null) => {
+    if (!date) return 'N/A';
+
+    if (!company) {
+        const prisma = new PrismaClient();
+        company = await prisma.company.findFirst();
+        if (!company) {
+            throw new Error('Company not found');
+        }
+    }
+
+    let dateFormat = company.dateFormat;
+    const allowedFormats = ['dd/mm/yyyy', 'mm/dd/yyyy', 'yyyy/mm/dd', 'dd.mm.yyyy', 'dd-mm-yyyy', 'yyyy-mm-dd', 'EEEE, dd MMM yyyy'];
+    if (!allowedFormats.includes(dateFormat)) {
+        dateFormat = 'dd/mm/yyyy'; // Default to dd/mm/yyyy if the format is not recognized
+    }
+    format(date, dateFormat);
+};

--- a/backend/src/utils/pdf.ts
+++ b/backend/src/utils/pdf.ts
@@ -1,0 +1,25 @@
+import * as puppeteer from 'puppeteer';
+
+export const getPDF = async (html: string) => {
+    let browser: puppeteer.Browser;
+    if (!process.env.PUPPETEER_EXECUTABLE_PATH) {
+        browser = await puppeteer.launch({
+            headless: true,
+            args: ['--no-sandbox', '--disable-setuid-sandbox'],
+        })
+    } else {
+        browser = await puppeteer.launch({
+            headless: true,
+            executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
+            args: ['--no-sandbox', '--disable-setuid-sandbox'],
+        });
+    }
+    const page = await browser.newPage();
+    await page.setContent(html, { waitUntil: 'networkidle0' });
+
+    const pdfBuffer = await page.pdf({ format: 'A4', printBackground: true });
+
+    await browser.close();
+
+    return pdfBuffer;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -119,6 +119,9 @@
   *::-webkit-scrollbar-thumb {
     @apply rounded-xl;
   }
+  html {
+    @apply overflow-hidden;
+  }
   body {
     @apply bg-background text-foreground;
   }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1009,6 +1009,14 @@
                         "required": "Invoice PDF format is required"
                     }
                 },
+                "dateFormat": {
+                    "label": "Date Format",
+                    "placeholder": "Select date format",
+                    "description": "Choose how dates will be displayed in quotes and invoices",
+                    "errors": {
+                        "required": "Date format is required"
+                    }
+                },
                 "saving": "Saving...",
                 "saveSettings": "Save Settings"
             },

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1009,6 +1009,14 @@
                         "required": "Le format du PDF de la facture est requis"
                     }
                 },
+                "dateFormat": {
+                    "label": "Format de date",
+                    "placeholder": "Sélectionner le format de date",
+                    "description": "Le format de date utilisé dans les devis et factures",
+                    "errors": {
+                        "required": "Le format de date est requis"
+                    }
+                },
                 "saving": "Enregistrement...",
                 "saveSettings": "Enregistrer les paramètres"
             },


### PR DESCRIPTION
This pull request introduces support for customizable date formats in quotes and invoices, refactors PDF generation logic, and updates the frontend to accommodate these changes. The most important changes focus on backend enhancements for date formatting and PDF generation, as well as frontend updates for user configuration of date formats.

### Backend Enhancements

#### Date Formatting:
* Added `dateFormat` field to the `Company` model in `schema.prisma` with a default value of `"dd/LL/yyyy"`. This allows companies to define their preferred date format for quotes and invoices.
* Created a new utility function `formatDate` in `backend/src/utils/date.ts` to format dates based on the company's `dateFormat`, with validation for allowed formats.

#### PDF Generation:
* Refactored PDF generation logic by moving Puppeteer-based code into a reusable `getPDF` function in `backend/src/utils/pdf.ts`. This simplifies the code and improves maintainability.
* Updated `InvoicesService` and `QuotesService` to use the new `getPDF` function for PDF generation and replaced inline date formatting with the `formatDate` utility. [[1]](diffhunk://#diff-d6efcb35719c600444a43bd030a8f01dec2e37de4ccc3dc3c5a2b4bbfdcc610cL325-R318) [[2]](diffhunk://#diff-e0e26074dd96304b93c737f800f0bf3611e8100202b3c47b8e00546abda9a4edL316-R320)

### Frontend Updates

#### Date Format Configuration:
* Added UI elements in `frontend/src/pages/(app)/settings/_components/company.settings.tsx` for selecting and validating date formats. Users can choose from predefined formats, and the selected format is displayed with an example. [[1]](diffhunk://#diff-210870cab32a730121e1f5fb960b37d49c8b1be0522999f652d4e78f6fc5d667R529-R554) [[2]](diffhunk://#diff-210870cab32a730121e1f5fb960b37d49c8b1be0522999f652d4e78f6fc5d667R186-R189)
* Updated localization files (`translation.json`) to include labels, placeholders, and error messages for the new date format field in both English and French. [[1]](diffhunk://#diff-a6916c1006782695d827d314f36c505fdfd8c99dfff19036f0d4ce039f626819R1012-R1019) [[2]](diffhunk://#diff-7835583c693a89af7d2396f3d183820faaa0eb59f7622643e89b36bd81b47d86R1012-R1019)

#### Styling:
* Modified `frontend/src/index.css` to hide overflow on the HTML element for improved UI consistency.