### PR TITLE
✨ feat: update email sending to use HTML format for signature emails

### DIFF
--- a/backend/src/models/signatures/signatures.service.ts
+++ b/backend/src/models/signatures/signatures.service.ts
@@ -200,7 +200,7 @@ export class SignaturesService {
             from: process.env.SMTP_FROM || process.env.SMTP_USER,
             to: email,
             subject: mailTemplate.subject.replace(/{{(\w+)}}/g, (_, key) => envVariables[key] || ''),
-            text: mailTemplate.body.replace(/{{(\w+)}}/g, (_, key) => envVariables[key] || ''),
+            html: mailTemplate.body.replace(/{{(\w+)}}/g, (_, key) => envVariables[key] || ''),
         };
 
         await this.transporter.sendMail(mailOptions)


### PR DESCRIPTION
This pull request makes a small but impactful change to the `SignaturesService` in `backend/src/models/signatures/signatures.service.ts`. The change updates the email format from plain text to HTML for better styling and presentation.

* [`backend/src/models/signatures/signatures.service.ts`](diffhunk://#diff-e10e17050d3e2c83092562c1a5da5dc47c05f860a835b2e616b522bb505943fcL203-R203): Changed the `mailOptions.text` property to `mailOptions.html` to send emails in HTML format instead of plain text.