### PR TITLE
🐛 fix: update invoice and quote templates to use postalCode instead of zip

### DIFF
--- a/backend/src/models/invoices/templates/base.template.ts
+++ b/backend/src/models/invoices/templates/base.template.ts
@@ -27,7 +27,7 @@ export const baseTemplate = `
             {{/if}}
             <h1>{{company.name}}</h1>
             <p>{{company.address}}<br>
-            {{company.city}}, {{company.zip}}<br>
+            {{company.city}}, {{company.postalCode}}<br>
             {{company.country}}<br>
             {{company.email}} | {{company.phone}}</p>
         </div>
@@ -42,7 +42,7 @@ export const baseTemplate = `
         <h3>{{labels.billTo}}</h3>
         <p>{{client.name}}<br>
         {{client.address}}<br>
-        {{client.city}}, {{client.zip}}<br>
+        {{client.city}}, {{client.postalCode}}<br>
         {{client.country}}<br>
         {{client.email}}</p>
     </div>

--- a/backend/src/models/quotes/templates/base.template.ts
+++ b/backend/src/models/quotes/templates/base.template.ts
@@ -28,7 +28,7 @@ export const baseTemplate = `
             {{/if}}
             <h1>{{company.name}}</h1>
             <p>{{company.address}}<br>
-            {{company.city}}, {{company.zip}}<br>
+            {{company.city}}, {{company.postalCode}}<br>
             {{company.country}}<br>
             {{company.email}} | {{company.phone}}</p>
         </div>
@@ -43,7 +43,7 @@ export const baseTemplate = `
         <h3>{{labels.quoteFor}}</h3>
         <p>{{client.name}}<br>
         {{client.address}}<br>
-        {{client.city}}, {{client.zip}}<br>
+        {{client.city}}, {{client.postalCode}}<br>
         {{client.country}}<br>
         {{client.email}}</p>
     </div>

--- a/frontend/src/pages/(app)/settings/_components/pdf.settings.tsx
+++ b/frontend/src/pages/(app)/settings/_components/pdf.settings.tsx
@@ -47,7 +47,7 @@ const defaultInvoiceTemplate = `
             {{/if}}
             <h1>{{company.name}}</h1>
             <p>{{company.address}}<br>
-            {{company.city}}, {{company.zip}}<br>
+            {{company.city}}, {{company.postalCode}}<br>
             {{company.country}}<br>
             {{company.email}} | {{company.phone}}</p>
         </div>
@@ -62,7 +62,7 @@ const defaultInvoiceTemplate = `
         <h3>{{labels.billTo}}</h3>
         <p>{{client.name}}<br>
         {{client.address}}<br>
-        {{client.city}}, {{client.zip}}<br>
+        {{client.city}}, {{client.postalCode}}<br>
         {{client.country}}<br>
         {{client.email}}</p>
     </div>
@@ -152,7 +152,7 @@ const defaultQuoteTemplate = `
             {{/if}}
             <h1>{{company.name}}</h1>
             <p>{{company.address}}<br>
-            {{company.city}}, {{company.zip}}<br>
+            {{company.city}}, {{company.postalCode}}<br>
             {{company.country}}<br>
             {{company.email}} | {{company.phone}}</p>
         </div>
@@ -167,7 +167,7 @@ const defaultQuoteTemplate = `
         <h3>{{labels.quoteFor}}</h3>
         <p>{{client.name}}<br>
         {{client.address}}<br>
-        {{client.city}}, {{client.zip}}<br>
+        {{client.city}}, {{client.postalCode}}<br>
         {{client.country}}<br>
         {{client.email}}</p>
     </div>
@@ -360,7 +360,7 @@ export default function PDFTemplatesSettings() {
                 name: "Acme Corporation",
                 address: "123 Business Street",
                 city: "New York",
-                zip: "10001",
+                postalCode: "10001",
                 email: "contact@acme.com",
                 phone: "+1 234 567 890",
             },
@@ -368,7 +368,7 @@ export default function PDFTemplatesSettings() {
                 name: "John Doe",
                 address: "456 Client Avenue",
                 city: "Los Angeles",
-                zip: "90001",
+                postalCode: "90001",
                 email: "john.doe@acme.com",
                 phone: "+1 987 654 321",
             },


### PR DESCRIPTION
This pull request updates the naming convention for postal codes across multiple templates and components to use `postalCode` instead of `zip`. The changes ensure consistency in the data model and improve clarity in both backend and frontend code.

### Backend updates:

* [`backend/src/models/invoices/templates/base.template.ts`](diffhunk://#diff-d93b99cce6f8d6f8ebb195577cc5d71886926491208fb6bc9d2143264d06dac1L30-R30): Replaced `{{company.zip}}` and `{{client.zip}}` with `{{company.postalCode}}` and `{{client.postalCode}}` in the invoice template. [[1]](diffhunk://#diff-d93b99cce6f8d6f8ebb195577cc5d71886926491208fb6bc9d2143264d06dac1L30-R30) [[2]](diffhunk://#diff-d93b99cce6f8d6f8ebb195577cc5d71886926491208fb6bc9d2143264d06dac1L45-R45)
* [`backend/src/models/quotes/templates/base.template.ts`](diffhunk://#diff-30e15c2843bf1f87455fd818042ebaa7f1838a1b483736dc198aaff1556d1401L31-R31): Replaced `{{company.zip}}` and `{{client.zip}}` with `{{company.postalCode}}` and `{{client.postalCode}}` in the quote template. [[1]](diffhunk://#diff-30e15c2843bf1f87455fd818042ebaa7f1838a1b483736dc198aaff1556d1401L31-R31) [[2]](diffhunk://#diff-30e15c2843bf1f87455fd818042ebaa7f1838a1b483736dc198aaff1556d1401L46-R46)

### Frontend updates:

* [`frontend/src/pages/(app)/settings/_components/pdf.settings.tsx`](diffhunk://#diff-fa3eb4472e85bbec525dafac1806369f0ea884ec9b6c87340fb90e93c3a81c50L50-R50): Updated `defaultInvoiceTemplate` and `defaultQuoteTemplate` to use `{{company.postalCode}}` and `{{client.postalCode}}` instead of `{{company.zip}}` and `{{client.zip}}`. [[1]](diffhunk://#diff-fa3eb4472e85bbec525dafac1806369f0ea884ec9b6c87340fb90e93c3a81c50L50-R50) [[2]](diffhunk://#diff-fa3eb4472e85bbec525dafac1806369f0ea884ec9b6c87340fb90e93c3a81c50L65-R65) [[3]](diffhunk://#diff-fa3eb4472e85bbec525dafac1806369f0ea884ec9b6c87340fb90e93c3a81c50L155-R155) [[4]](diffhunk://#diff-fa3eb4472e85bbec525dafac1806369f0ea884ec9b6c87340fb90e93c3a81c50L170-R170)
* [`frontend/src/pages/(app)/settings/_components/pdf.settings.tsx`](diffhunk://#diff-fa3eb4472e85bbec525dafac1806369f0ea884ec9b6c87340fb90e93c3a81c50L363-R371): Modified the `PDFTemplatesSettings` function to rename `zip` to `postalCode` in the mock data for both `company` and `client`.