### PR TITLE
🔧 refactor: remove LoginRequired decorator from OTP generation and signing endpoints

### DIFF
--- a/backend/src/models/signatures/signatures.controller.ts
+++ b/backend/src/models/signatures/signatures.controller.ts
@@ -20,13 +20,11 @@ export class SignaturesController {
     }
 
     @Post('/:id/otp')
-    @LoginRequired()
     async generateOTPCode(@Param('id') signatureId: string) {
         return this.signaturesService.generateOTPCode(signatureId);
     }
 
     @Post('/:id/sign')
-    @LoginRequired()
     async signQuote(@Param('id') signatureId: string, @Body('otpCode') otpCode: string) {
         return this.signaturesService.signQuote(signatureId, otpCode);
     }


### PR DESCRIPTION
This pull request modifies the `SignaturesController` in `backend/src/models/signatures/signatures.controller.ts` by removing the `@LoginRequired()` decorator from two methods. These changes adjust the authentication requirements for generating OTP codes and signing quotes.

Authentication changes:

* Removed the `@LoginRequired()` decorator from the `generateOTPCode` method, making it accessible without requiring user login. (`[backend/src/models/signatures/signatures.controller.tsL23-L29](diffhunk://#diff-5c79aaabae09c8bc41f0f5e1a95a705867b1dfad7e49217d5452f8ab007930e0L23-L29)`)
* Removed the `@LoginRequired()` decorator from the `signQuote` method, allowing it to be called without user authentication. (`[backend/src/models/signatures/signatures.controller.tsL23-L29](diffhunk://#diff-5c79aaabae09c8bc41f0f5e1a95a705867b1dfad7e49217d5452f8ab007930e0L23-L29)`)