### PR TITLE
fix: remove "viewed at" and "signed by"

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -329,7 +329,6 @@
                 "createdAt": "Created",
                 "validUntil": "Valid Until",
                 "signedAt": "Signed At",
-                "viewedAt": "Viewed At",
                 "client": "Client",
                 "signedBy": "Signed By",
                 "totalHT": "Total (excl. VAT)",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -329,7 +329,6 @@
                 "createdAt": "Créé le",
                 "validUntil": "Valide jusqu'au",
                 "signedAt": "Signé le",
-                "viewedAt": "Consulté le",
                 "client": "Client",
                 "signedBy": "Signé par",
                 "totalHT": "Total HT",

--- a/frontend/src/pages/(app)/quotes/_components/quote-view.tsx
+++ b/frontend/src/pages/(app)/quotes/_components/quote-view.tsx
@@ -58,11 +58,6 @@ export function QuoteViewDialog({ quote, onOpenChange }: QuoteViewDialogProps) {
                             <p className="text-sm text-muted-foreground">{t("quotes.view.fields.signedAt")}</p>
                             <p className="font-medium">{formatDate(quote.signedAt)}</p>
                         </div>
-
-                        <div>
-                            <p className="text-sm text-muted-foreground">{t("quotes.view.fields.viewedAt")}</p>
-                            <p className="font-medium">{formatDate(quote.viewedAt)}</p>
-                        </div>
                     </div>
 
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 bg-muted/50 p-4 rounded-lg">
@@ -71,10 +66,12 @@ export function QuoteViewDialog({ quote, onOpenChange }: QuoteViewDialogProps) {
                             <p className="font-medium">{quote.client.name}</p>
                         </div>
 
-                        <div>
-                            <p className="text-sm text-muted-foreground">{t("quotes.view.fields.signedBy")}</p>
-                            <p className="font-medium">{quote.signedBy || "—"}</p>
-                        </div>
+                        {!!quote.signedAt && (
+                            <div>
+                                <p className="text-sm text-muted-foreground">{t("quotes.view.fields.signedBy")}</p>
+                                <p className="font-medium">{quote.client.contactEmail || "—"}</p>
+                            </div>
+                        )}
                     </div>
 
                     <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 bg-muted/50 p-4 rounded-lg">

--- a/frontend/src/types/quote.ts
+++ b/frontend/src/types/quote.ts
@@ -23,8 +23,6 @@ export interface Quote {
     updatedAt: Date;
     validUntil?: Date;
     signedAt?: Date;
-    viewedAt?: Date;
-    signedBy?: string;
     signatureSvg?: string;
     notes?: string; // Additional notes for the quote
     totalHT: number;


### PR DESCRIPTION
This pull request removes the `viewedAt` and `signedBy` fields from the `Quote` interface and updates related components and translations accordingly. It also introduces a conditional display for the `signedBy` field, replacing it with the client's contact email if available.

### Changes to `Quote` data model:
* Removed the `viewedAt` and `signedBy` fields from the `Quote` interface in `frontend/src/types/quote.ts`. (`[frontend/src/types/quote.tsL26-L27](diffhunk://#diff-40912db15a733c4ae040eb69a4cd7df29a2c093f89d04f1da45cca2e30a06e2fL26-L27)`)

### Updates to UI components:
* Removed the `viewedAt` field from the `QuoteViewDialog` component in `frontend/src/pages/(app)/quotes/_components/quote-view.tsx`. (`[frontend/src/pages/(app)/quotes/_components/quote-view.tsxL61-L65](diffhunk://#diff-c2651886d7a6c9d8c3743be11604ec7eb5793430480e819cfa3e43945bde8529L61-L65)`)
* Updated the `signedBy` field in the `QuoteViewDialog` component to conditionally display the client's contact email instead, if `signedAt` is present. (`[frontend/src/pages/(app)/quotes/_components/quote-view.tsxR69-R74](diffhunk://#diff-c2651886d7a6c9d8c3743be11604ec7eb5793430480e819cfa3e43945bde8529R69-R74)`)

### Translation updates:
* Removed the `viewedAt` translation key from the English locale in `frontend/src/locales/en/translation.json`. (`[frontend/src/locales/en/translation.jsonL332](diffhunk://#diff-a6916c1006782695d827d314f36c505fdfd8c99dfff19036f0d4ce039f626819L332)`)
* Removed the `viewedAt` translation key from the French locale in `frontend/src/locales/fr/translation.json`. (`[frontend/src/locales/fr/translation.jsonL332](diffhunk://#diff-7835583c693a89af7d2396f3d183820faaa0eb59f7622643e89b36bd81b47d86L332)`)