### PR TITLE
feat: make vat id an optional field for company

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -194,9 +194,9 @@ model Company {
   name        String
   description String
   currency    Currency @default(EUR)
-  legalId     String
+  legalId     String?
   foundedAt   DateTime
-  VAT         String
+  VAT         String?
   address     String
   postalCode  String
   city        String

--- a/backend/src/models/company/dto/company.dto.ts
+++ b/backend/src/models/company/dto/company.dto.ts
@@ -34,11 +34,11 @@ export interface PDFConfig {
 
 export class EditCompanyDto {
     description: string
-    legalId: string
+    legalId?: string
     foundedAt: Date
     name: string
     currency: finance.TCurrency
-    VAT: string
+    VAT?: string
     address: string
     postalCode: string
     city: string

--- a/backend/src/models/invoices/invoices.service.ts
+++ b/backend/src/models/invoices/invoices.service.ts
@@ -357,7 +357,7 @@ export class InvoicesService {
                 country: invRec.company.country,
                 countryCode: invRec.company.country
             },
-            registrationDetails: { vatId: invRec.company.VAT, registrationId: invRec.company.legalId, registrationName: invRec.company.name }
+            registrationDetails: { vatId: invRec.company.VAT || "N/A", registrationId: invRec.company.legalId || "N/A", registrationName: invRec.company.name }
         };
 
         inv.to = {

--- a/frontend/src/pages/(app)/settings/_components/company.settings.tsx
+++ b/frontend/src/pages/(app)/settings/_components/company.settings.tsx
@@ -69,14 +69,13 @@ export default function CompanySettings() {
         legalId: z
             .string({ required_error: t("settings.company.form.legalId.errors.required") })
             .min(1, t("settings.company.form.legalId.errors.empty"))
-            .max(50, t("settings.company.form.legalId.errors.maxLength")),
+            .max(50, t("settings.company.form.legalId.errors.maxLength"))
+            .optional(),
         VAT: z
             .string({ required_error: t("settings.company.form.vat.errors.required") })
             .min(1, t("settings.company.form.vat.errors.empty"))
             .max(15, t("settings.company.form.vat.errors.maxLength"))
-            .refine((val) => {
-                return /^[A-Z]{2}[0-9A-Z]{8,12}$/.test(val)
-            }, t("settings.company.form.vat.errors.format")),
+            .optional(),
         foundedAt: z.date().refine((date) => date <= new Date(), t("settings.company.form.foundedAt.errors.future")),
         currency: z
             .string({ required_error: t("settings.company.form.currency.errors.required") })
@@ -276,7 +275,7 @@ export default function CompanySettings() {
                                     name="legalId"
                                     render={({ field }) => (
                                         <FormItem>
-                                            <FormLabel required>{t("settings.company.form.legalId.label")}</FormLabel>
+                                            <FormLabel>{t("settings.company.form.legalId.label")}</FormLabel>
                                             <FormControl>
                                                 <Input placeholder={t("settings.company.form.legalId.placeholder")} {...field} />
                                             </FormControl>
@@ -291,7 +290,7 @@ export default function CompanySettings() {
                                     name="VAT"
                                     render={({ field }) => (
                                         <FormItem>
-                                            <FormLabel required>{t("settings.company.form.vat.label")}</FormLabel>
+                                            <FormLabel>{t("settings.company.form.vat.label")}</FormLabel>
                                             <FormControl>
                                                 <Input placeholder={t("settings.company.form.vat.placeholder")} {...field} />
                                             </FormControl>


### PR DESCRIPTION
This pull request introduces changes to make the `legalId` and `VAT` fields optional across the backend and frontend, ensuring better flexibility and handling of missing data. Key updates include adjustments to database schema, DTOs, form validation, and default handling in services.

### Backend Changes:
* **Database Schema (`schema.prisma`)**: Updated the `Company` model to make `legalId` and `VAT` fields optional by changing their types to `String?`.
* **DTO Updates (`company.dto.ts`)**: Modified the `EditCompanyDto` to reflect the optional nature of `legalId` and `VAT` by appending the `?` operator to their types.
* **Service Logic (`invoices.service.ts`)**: Updated the `InvoicesService` to provide default values ("N/A") for `VAT` and `legalId` when they are missing.

### Frontend Changes:
* **Form Validation (`company.settings.tsx`)**: Adjusted the validation schema to make `legalId` and `VAT` optional and removed the strict format validation for `VAT`.
* **Form Labels (`company.settings.tsx`)**: Removed the "required" indicator from the form labels for `legalId` and `VAT` to align with their optional status. [[1]](diffhunk://#diff-210870cab32a730121e1f5fb960b37d49c8b1be0522999f652d4e78f6fc5d667L279-R278) [[2]](diffhunk://#diff-210870cab32a730121e1f5fb960b37d49c8b1be0522999f652d4e78f6fc5d667L294-R293)