### PR TITLE
fix: make default vat at 0

### DIFF
--- a/frontend/src/pages/(app)/invoices/_components/invoice-upsert.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-upsert.tsx
@@ -182,7 +182,7 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
         <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent className="max-w-sm lg:max-w-4xl min-w-fit">
                 <DialogHeader>
-                    <DialogTitle>{t(`invoices.upsert.title.${isEdit ? "edit" : "create"}`)}</DialogTitle>
+                    <DialogTitle>{t(`invoices.upsert.title.upsert`)}</DialogTitle>
                 </DialogHeader>
                 <Form {...form}>
                     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
@@ -357,7 +357,7 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
                                                                     <Input
                                                                         {...field}
                                                                         placeholder={t(
-                                                                            `invoices.${isEdit ? "edit" : "create"}.form.items.description.placeholder`,
+                                                                            `invoices.upsert.form.items.description.placeholder`,
                                                                         )}
                                                                     />
                                                                 </FormControl>
@@ -375,10 +375,10 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
                                                                     <BetterInput
                                                                         {...field}
                                                                         defaultValue={field.value || ""}
-                                                                        postAdornment={t(`invoices.${isEdit ? "edit" : "create"}.form.items.quantity.unit`)}
+                                                                        postAdornment={t(`invoices.upsert.form.items.quantity.unit`)}
                                                                         type="number"
                                                                         placeholder={t(
-                                                                            `invoices.${isEdit ? "edit" : "create"}.form.items.quantity.placeholder`,
+                                                                            `invoices.upsert.form.items.quantity.placeholder`,
                                                                         )}
                                                                         onChange={(e) =>
                                                                             field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
@@ -402,7 +402,7 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
                                                                         postAdornment="$"
                                                                         type="number"
                                                                         placeholder={t(
-                                                                            `invoices.${isEdit ? "edit" : "create"}.form.items.unitPrice.placeholder`,
+                                                                            `invoices.upsert.form.items.unitPrice.placeholder`,
                                                                         )}
                                                                         onChange={(e) =>
                                                                             field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
@@ -422,12 +422,12 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
                                                                 <FormControl>
                                                                     <BetterInput
                                                                         {...field}
-                                                                        defaultValue={field.value || ""}
+                                                                        defaultValue={field.value || 0}
                                                                         postAdornment="%"
                                                                         type="number"
                                                                         step="0.01"
                                                                         placeholder={t(
-                                                                            `invoices.${isEdit ? "edit" : "create"}.form.items.vatRate.placeholder`,
+                                                                            `invoices.upsert.form.items.vatRate.placeholder`,
                                                                         )}
                                                                         onChange={(e) =>
                                                                             field.onChange(

--- a/frontend/src/pages/(app)/invoices/_components/recurring-invoices/recurring-invoices-upsert.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/recurring-invoices/recurring-invoices-upsert.tsx
@@ -201,7 +201,7 @@ export function RecurringInvoiceUpsert({ recurringInvoice, open, onOpenChange }:
         <Dialog open={open} onOpenChange={handleClose}>
             <DialogContent className="max-w-[95vw] lg:max-w-3xl max-h-[90dvh] flex flex-col overflow-hidden">
                 <DialogHeader>
-                    <DialogTitle>{t(`recurringInvoices.upsert.title.${isEdit ? "edit" : "create"}`)}</DialogTitle>
+                    <DialogTitle>{t(`recurringInvoices.upsert.title.upsert`)}</DialogTitle>
                 </DialogHeader>
                 <Form {...form}>
                     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 overflow-auto mt-2 flex-1">

--- a/frontend/src/pages/(app)/invoices/_components/recurring-invoices/recurring-invoices-upsert.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/recurring-invoices/recurring-invoices-upsert.tsx
@@ -514,7 +514,7 @@ export function RecurringInvoiceUpsert({ recurringInvoice, open, onOpenChange }:
                                                                 <FormControl>
                                                                     <BetterInput
                                                                         {...field}
-                                                                        defaultValue={field.value}
+                                                                        defaultValue={field.value || 0}
                                                                         postAdornment="%"
                                                                         type="number"
                                                                         step="0.01"

--- a/frontend/src/pages/(app)/quotes/_components/quote-upsert.tsx
+++ b/frontend/src/pages/(app)/quotes/_components/quote-upsert.tsx
@@ -189,7 +189,7 @@ export function QuoteUpsert({ quote, open, onOpenChange }: QuoteUpsertDialogProp
         <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent className="max-w-sm lg:max-w-4xl min-w-fit">
                 <DialogHeader>
-                    <DialogTitle>{t(`quotes.upsert.title.${isEdit ? "edit" : "create"}`)}</DialogTitle>
+                    <DialogTitle>{t(`quotes.upsert.title.upsert`)}</DialogTitle>
                 </DialogHeader>
                 <Form {...form}>
                     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
@@ -338,7 +338,7 @@ export function QuoteUpsert({ quote, open, onOpenChange }: QuoteUpsertDialogProp
                                                                     <Input
                                                                         {...field}
                                                                         placeholder={t(
-                                                                            `quotes.${isEdit ? "edit" : "create"}.form.items.description.placeholder`,
+                                                                            `quotes.upsert.form.items.description.placeholder`,
                                                                         )}
                                                                     />
                                                                 </FormControl>
@@ -356,10 +356,10 @@ export function QuoteUpsert({ quote, open, onOpenChange }: QuoteUpsertDialogProp
                                                                     <BetterInput
                                                                         {...field}
                                                                         defaultValue={field.value || ""}
-                                                                        postAdornment={t(`quotes.${isEdit ? "edit" : "create"}.form.items.quantity.unit`)}
+                                                                        postAdornment={t(`quotes.upsert.form.items.quantity.unit`)}
                                                                         type="number"
                                                                         placeholder={t(
-                                                                            `quotes.${isEdit ? "edit" : "create"}.form.items.quantity.placeholder`,
+                                                                            `quotes.upsert.form.items.quantity.placeholder`,
                                                                         )}
                                                                         onChange={(e) =>
                                                                             field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
@@ -383,7 +383,7 @@ export function QuoteUpsert({ quote, open, onOpenChange }: QuoteUpsertDialogProp
                                                                         postAdornment="$"
                                                                         type="number"
                                                                         placeholder={t(
-                                                                            `quotes.${isEdit ? "edit" : "create"}.form.items.unitPrice.placeholder`,
+                                                                            `quotes.upsert.form.items.unitPrice.placeholder`,
                                                                         )}
                                                                         onChange={(e) =>
                                                                             field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
@@ -408,7 +408,7 @@ export function QuoteUpsert({ quote, open, onOpenChange }: QuoteUpsertDialogProp
                                                                         type="number"
                                                                         step="0.01"
                                                                         placeholder={t(
-                                                                            `quotes.${isEdit ? "edit" : "create"}.form.items.vatRate.placeholder`,
+                                                                            `quotes.upsert.form.items.vatRate.placeholder`,
                                                                         )}
                                                                         onChange={(e) =>
                                                                             field.onChange(


### PR DESCRIPTION
This pull request refactors localization keys across several components (`InvoiceUpsert`, `RecurringInvoiceUpsert`, and `QuoteUpsert`) to simplify and standardize the translation strings. It also introduces a default value of `0` for numeric fields where applicable. Below is a breakdown of the most important changes:

### Localization Key Simplification
* Updated translation keys for titles in `InvoiceUpsert`, `RecurringInvoiceUpsert`, and `QuoteUpsert` components to use a unified `upsert` key instead of conditionally checking for `edit` or `create`. (`[[1]](diffhunk://#diff-625bff1770564d80b3c3039cbf5994022851dc2b3adab697e9834df3ace41e84L185-R185)`, `[[2]](diffhunk://#diff-b8617029e80c9590dcd93310c0bd292171b58d50012c3c6657064b2b9d2b00d8L204-R204)`, `[[3]](diffhunk://#diff-03cfc0743d217ebc602b83f674124401931e5e9796de6925ebf7e18ee3fbb8d0L192-R192)`)
* Replaced conditional translation keys for placeholders and adornments in form fields with unified `upsert` keys across all three components. (`[[1]](diffhunk://#diff-625bff1770564d80b3c3039cbf5994022851dc2b3adab697e9834df3ace41e84L360-R360)`, `[[2]](diffhunk://#diff-625bff1770564d80b3c3039cbf5994022851dc2b3adab697e9834df3ace41e84L378-R381)`, `[[3]](diffhunk://#diff-625bff1770564d80b3c3039cbf5994022851dc2b3adab697e9834df3ace41e84L405-R405)`, `[[4]](diffhunk://#diff-03cfc0743d217ebc602b83f674124401931e5e9796de6925ebf7e18ee3fbb8d0L341-R341)`, `[[5]](diffhunk://#diff-03cfc0743d217ebc602b83f674124401931e5e9796de6925ebf7e18ee3fbb8d0L359-R362)`, `[[6]](diffhunk://#diff-03cfc0743d217ebc602b83f674124401931e5e9796de6925ebf7e18ee3fbb8d0L386-R386)`, `[[7]](diffhunk://#diff-03cfc0743d217ebc602b83f674124401931e5e9796de6925ebf7e18ee3fbb8d0L411-R411)`)

### Default Value Adjustments
* Set a default value of `0` for numeric fields (e.g., VAT rate) in `InvoiceUpsert`, `RecurringInvoiceUpsert`, and `QuoteUpsert` components to handle empty inputs more gracefully. (`[[1]](diffhunk://#diff-625bff1770564d80b3c3039cbf5994022851dc2b3adab697e9834df3ace41e84L425-R430)`, `[[2]](diffhunk://#diff-b8617029e80c9590dcd93310c0bd292171b58d50012c3c6657064b2b9d2b00d8L517-R517)`)