### PR TITLE
🔧 config: Remove unnecessary dumb-init installation from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,7 @@ RUN apt-get install -y \
     ttf-freefont \
     chromium-chromedriver \
     bash \
-    dumb-init \
-    && rm -rf /var/cache/apk/*
+    dumb-init
 
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 ENV PLUGIN_DIR=/usr/share/nginx/plugins


### PR DESCRIPTION
This pull request makes a minor adjustment to the `Dockerfile` by modifying the installation process for dependencies.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L40-R40): Removed the cleanup command `&& rm -rf /var/cache/apk*` from the `RUN apt-get install -y` block, leaving the `dumb-init` installation unchanged.