### PR TITLE
🔧 config: Update package installation commands for Chromium dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,11 @@ RUN apt-get update && apt-get install -y \
 
 RUN apt-get install -y \
     chromium \
-    nss \
-    freetype \
-    harfbuzz \
-    ttf-freefont \
-    chromium-chromedriver \
+    libnss3 \
+    libfreetype6 \
+    libharfbuzz0b \
+    fonts-freefont-ttf \
+    chromium-driver \
     bash \
     dumb-init
 


### PR DESCRIPTION
This pull request updates the `Dockerfile` to replace deprecated or incorrect package names with their modern equivalents, ensuring compatibility and reducing potential build issues.

### Updates to package dependencies:
* Replaced `nss` with `libnss3` to use the correct library package.
* Replaced `freetype` with `libfreetype6` for the updated package name.
* Replaced `harfbuzz` with `libharfbuzz0b` for the correct library version.
* Replaced `ttf-freefont` with `fonts-freefont-ttf` for the updated font package.
* Replaced `chromium-chromedriver` with `chromium-driver` for the correct driver package.