### PR TITLE
feat: add cors urls env variable

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -7,7 +7,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableCors({
     credentials: true,
-    origin: ['http://localhost:5173', process.env.APP_URL, ...(process.env.CORS_ORIGINS?.split(',').map(o => o.trim()).filter(val => !!val) || [])],
+    origin: ['http://localhost:5173', process.env.APP_URL, ...(process.env.CORS_ORIGINS?.split(',').map(o => o.trim()) || [])].filter(Boolean),
   });
   app.use(cookieParser());
   app.setGlobalPrefix('api');

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -7,9 +7,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableCors({
     credentials: true,
-    origin: (_origin, callback) => {
-      callback(null, true);
-    }
+    origin: ['http://localhost:5173', process.env.APP_URL, ...(process.env.CORS_ORIGINS?.split(',').map(o => o.trim()).filter(val => !!val) || [])],
   });
   app.use(cookieParser());
   app.setGlobalPrefix('api');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - DATABASE_URL=postgresql://invoicerr:invoicerr@invoicerr_db:5432/invoicerr_db
 
       - APP_URL=https://invoicerr.example.com # Required for email templates, as it redirects to the app
+      - CORS_ORIGINS=http://localhost:5173,https://invoicerr.example.com # Comma-separated list of allowed origins for CORS
 
       # Required for email features
       - SMTP_HOST=smtp-relay.example.com


### PR DESCRIPTION
This pull request introduces updates to the CORS configuration in the backend and Docker setup to improve security and flexibility. The changes ensure that the application properly handles allowed origins for cross-origin requests.

### Backend CORS Configuration Updates:
* [`backend/src/main.ts`](diffhunk://#diff-0449806ce2081366f836dc87b621852253e839c09a6c5b12461ab4433186e289L10-R10): Modified the `origin` property in the `enableCors` method to use a dynamic list of allowed origins, including `http://localhost:5173`, the value of `APP_URL`, and any additional origins specified in the `CORS_ORIGINS` environment variable.

### Docker Environment Variable Addition:
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R10): Added a new `CORS_ORIGINS` environment variable to specify a comma-separated list of allowed origins for CORS, including `http://localhost:5173` and `https://invoicerr.example.com`.