### PR TITLE
🔧 config: Add PUPPETEER_EXECUTABLE_PATH environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN npm run build
 FROM ghcr.io/impre-visible/invoicerr-server-image:latest
 
 ENV PLUGIN_DIR=/usr/share/nginx/plugins
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
 COPY --from=frontend-builder /app/dist /usr/share/nginx/html
 


### PR DESCRIPTION
This pull request introduces an update to the `Dockerfile` to enhance Puppeteer support by specifying the Chromium executable path.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R29): Added the `PUPPETEER_EXECUTABLE_PATH` environment variable to specify the location of the Chromium binary, ensuring compatibility with Puppeteer.