### PR TITLE
🐛 Fix: uploading of logo > 100kb

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,4 +1,5 @@
 import * as cookieParser from 'cookie-parser';
+import * as bodyParser from 'body-parser';
 
 import { AppModule } from './app.module';
 import { NestFactory } from '@nestjs/core';
@@ -11,10 +12,11 @@ async function bootstrap() {
   });
   app.use(cookieParser());
   app.setGlobalPrefix('api');
+  app.use(bodyParser.json({ limit: '1mb' }));
   app.use((_req, res, next) => {
     res.header('Access-Control-Expose-Headers', 'WWW-Authenticate');
     next();
-  })
+  });
   await app.listen(process.env.PORT || 3000);
 }
 bootstrap();


### PR DESCRIPTION
Express is limiting uploads to 100kB. If a logo gets close to this, the body of the JSON message gets too big and is trashed. This PR increase the JSON-parser allowed Body size to 1MB, which should be fine even for higher res logos. 