### PR TITLE
test: set workflow arch to arm64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-arm
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,16 +24,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set image tag
+      - name: Set image tags
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "IMAGE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+            TAG=${GITHUB_REF#refs/tags/}
+            echo "IMAGE_TAGS=ghcr.io/${{ github.repository }}:${TAG},ghcr.io/${{ github.repository }}:latest" >> $GITHUB_ENV
           elif [[ "${GITHUB_REF}" == refs/heads/* ]]; then
             BRANCH_NAME=${GITHUB_REF#refs/heads/}
             SAFE_BRANCH_NAME=${BRANCH_NAME//\//-}
-            echo "IMAGE_TAG=${SAFE_BRANCH_NAME}" >> $GITHUB_ENV
+            echo "IMAGE_TAGS=ghcr.io/${{ github.repository }}:${SAFE_BRANCH_NAME}" >> $GITHUB_ENV
           else
-            echo "IMAGE_TAG=latest" >> $GITHUB_ENV
+            echo "IMAGE_TAGS=ghcr.io/${{ github.repository }}:latest" >> $GITHUB_ENV
           fi
 
       - name: Extract metadata
@@ -66,7 +67,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ env.REPO_NAME_LOWER }}:${{ env.IMAGE_TAG }}
+          tags: ${{ env.IMAGE_TAGS }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha,scope=repository,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,17 +24,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Lowercase repo name
+        run: echo "REPO_NAME_LOWER=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Set image tags
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG=${GITHUB_REF#refs/tags/}
-            echo "IMAGE_TAGS=ghcr.io/${{ github.repository }}:${TAG},ghcr.io/${{ github.repository }}:latest" >> $GITHUB_ENV
+            echo "IMAGE_TAGS=ghcr.io/${REPO_NAME_LOWER}:${TAG},ghcr.io/${REPO_NAME_LOWER}:latest" >> $GITHUB_ENV
           elif [[ "${GITHUB_REF}" == refs/heads/* ]]; then
             BRANCH_NAME=${GITHUB_REF#refs/heads/}
             SAFE_BRANCH_NAME=${BRANCH_NAME//\//-}
-            echo "IMAGE_TAGS=ghcr.io/${{ github.repository }}:${SAFE_BRANCH_NAME}" >> $GITHUB_ENV
+            echo "IMAGE_TAGS=ghcr.io/${REPO_NAME_LOWER}:${SAFE_BRANCH_NAME}" >> $GITHUB_ENV
           else
-            echo "IMAGE_TAGS=ghcr.io/${{ github.repository }}:latest" >> $GITHUB_ENV
+            echo "IMAGE_TAGS=ghcr.io/${REPO_NAME_LOWER}:latest" >> $GITHUB_ENV
           fi
 
       - name: Extract metadata
@@ -55,8 +58,6 @@ jobs:
             [worker.oci]
               max-parallelism = 8
 
-      - name: Lowercase repo name
-        run: echo "REPO_NAME_LOWER=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Check Docker cache
         run: |


### PR DESCRIPTION
This pull request updates the `.github/workflows/docker-publish.yml` file to enhance compatibility and improve the tagging logic for Docker images. The key changes include switching to a specific Ubuntu version for the runner, consolidating the repository name handling, and refining the image tagging process.

### Workflow Updates:

* **Runner Update**: Changed the runner from `ubuntu-latest` to `ubuntu-22.04-arm` to ensure compatibility with ARM-based builds. (`[.github/workflows/docker-publish.ymlL12-R12](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L12-R12)`)

* **Repository Name Handling**:
  - Moved the step to lowercase the repository name earlier in the workflow for better organization. (`[[1]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L27-R40)`, `[[2]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L57-L58)`)

### Docker Image Tagging Improvements:

* **Dynamic Tagging**:
  - Enhanced the tagging logic to support multiple tags (e.g., specific version and `latest` for tags, or branch name for branches). (`[.github/workflows/docker-publish.ymlL27-R40](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L27-R40)`)
  - Updated the Docker build step to use the new `IMAGE_TAGS` variable for multiple tags instead of a single tag. (`[.github/workflows/docker-publish.ymlL69-R71](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L69-R71)`)