### PR TITLE
♻️ refactor: Change runner to use ubuntu-latest for Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
This pull request includes a small but important update to the `.github/workflows/docker-publish.yml` file. The change updates the runner environment for the `build-and-push` job to use the latest Ubuntu version for better compatibility and future-proofing.