### PR TITLE
test: update workflow scope for better caching

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,10 +40,13 @@ jobs:
             echo "IMAGE_TAGS=ghcr.io/${REPO_NAME_LOWER}:latest" >> $GITHUB_ENV
           fi
 
-      - name: Change Github Ref if in a tag
+      - name: Set CACHE_REF based on Git ref
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "GITHUB_REF='release'" >> $GITHUB_ENV
+            echo "CACHE_REF=release" >> $GITHUB_ENV
+          else
+            # Extrait le nom de la branche
+            echo "CACHE_REF=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
           fi
 
       - name: Extract metadata
@@ -77,5 +80,5 @@ jobs:
           tags: ${{ env.IMAGE_TAGS }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
-          cache-from: type=gha,scope=repository,mode=max
-          cache-to: type=gha,mode=max,scope=repository
+          cache-from: type=gha,mode=max,scope=${{ env.CACHE_REF }}
+          cache-to: type=gha,mode=max,scope=${{ env.CACHE_REF }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,6 +40,12 @@ jobs:
             echo "IMAGE_TAGS=ghcr.io/${REPO_NAME_LOWER}:latest" >> $GITHUB_ENV
           fi
 
+      - name: Change Github Ref if in a tag
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "GITHUB_REF='release'" >> $GITHUB_ENV
+          fi
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
This pull request updates the Docker publishing workflow to improve caching behavior by dynamically setting the cache scope based on the Git reference. The changes ensure more efficient caching for both release tags and branch builds.

### Improvements to caching in the Docker publishing workflow:

* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R43-R51): Added a step to set the `CACHE_REF` environment variable dynamically based on whether the Git reference is a tag or a branch. For tags, the cache scope is set to `release`, while for branches, it uses the branch name.
* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L74-R84): Updated the `cache-from` and `cache-to` configurations in the Docker build step to use the dynamically set `CACHE_REF` value as the cache scope.