### PR TITLE
fix: replace LL with MM

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -214,7 +214,7 @@ model Company {
 
   invoicePDFFormat String @default("facturx") // Ex: 'pdf' | 'facturx' | 'zugferd' | 'xrechnung' | 'ubl' | 'cii'
 
-  dateFormat String @default("dd/LL/yyyy") // Date format for quotes and invoices
+  dateFormat String @default("dd/MM/yyyy") // Date format for quotes and invoices
 
   pDFConfigId      String             @unique
   pdfConfig        PDFConfig          @relation(fields: [pDFConfigId], references: [id])

--- a/backend/src/utils/date.ts
+++ b/backend/src/utils/date.ts
@@ -1,14 +1,13 @@
-import { Company, PrismaClient } from "@prisma/client";
-
+import { Company } from "@prisma/client";
 import { format } from "date-fns";
 
 export const formatDate = (company: Company, date?: Date | null,) => {
     if (!date) return 'N/A';
 
     let dateFormat = company.dateFormat;
-    const allowedFormats = ['dd/LL/yyyy', 'LL/dd/yyyy', 'yyyy/LL/dd', 'dd.LL.yyyy', 'dd-LL-yyyy', 'yyyy-LL-dd', 'EEEE, dd MMM yyyy'];
+    const allowedFormats = ['dd/MM/yyyy', 'MM/dd/yyyy', 'yyyy/MM/dd', 'dd.MM.yyyy', 'dd-MM-yyyy', 'yyyy-MM-dd', 'EEEE, dd MMM yyyy'];
     if (!allowedFormats.includes(dateFormat)) {
-        dateFormat = 'dd/LL/yyyy'; // Default format if the stored format is invalid
+        dateFormat = 'dd/MM/yyyy'; // Default format if the stored format is invalid
     }
     return format(date, dateFormat);
 };

--- a/frontend/src/pages/(app)/settings/_components/company.settings.tsx
+++ b/frontend/src/pages/(app)/settings/_components/company.settings.tsx
@@ -21,7 +21,7 @@ export default function CompanySettings() {
     const { t } = useTranslation()
     const navigate = useNavigate()
 
-    const ALLOWED_DATE_FORMATS = ['dd/LL/yyyy', 'LL/dd/yyyy', 'yyyy/LL/dd', 'dd.LL.yyyy', 'dd-LL-yyyy', 'yyyy-LL-dd', 'EEEE, dd MMM yyyy'];
+    const ALLOWED_DATE_FORMATS = ['dd/MM/yyyy', 'MM/dd/yyyy', 'yyyy/MM/dd', 'dd.MM.yyyy', 'dd-MM-yyyy', 'yyyy-MM-dd', 'EEEE, dd MMM yyyy'];
 
     const validateNumberFormat = (pattern: string): boolean => {
         const patternRegex = /\{(\w+)(?::(\d+))?\}/g


### PR DESCRIPTION
This pull request standardizes the date format handling across the backend and frontend by switching from using `LL` (month) with slashes to the more conventional `MM` for months. It updates the allowed date formats and default values to ensure consistency and compatibility throughout the application.

**Date format standardization:**

* Updated the default `dateFormat` in the `Company` model from `'dd/LL/yyyy'` to `'dd/MM/yyyy'` in `schema.prisma`, ensuring the default uses the conventional month notation.
* Updated the allowed date formats in both the frontend (`company.settings.tsx`) and backend (`date.ts`) to use `'MM'` instead of `'LL'` for months, and replaced formats accordingly. [[1]](diffhunk://#diff-210870cab32a730121e1f5fb960b37d49c8b1be0522999f652d4e78f6fc5d667L24-R24) [[2]](diffhunk://#diff-4152e610e0061008a021601bd7282b16e258b2695d51756998b7b51e9e18ae19L1-R10)
* Changed the fallback date format in the backend date formatting utility from `'dd/LL/yyyy'` to `'dd/MM/yyyy'` to match the new standard.