### PR TITLE
♻️ refactor: Move JWKS initialization inside OIDC_JWKS_URI check

### DIFF
--- a/backend/src/guards/login-required.guard.ts
+++ b/backend/src/guards/login-required.guard.ts
@@ -21,10 +21,12 @@ export class LoginRequiredGuard implements CanActivate {
     private readonly jwt: JwtService,
     private readonly prisma: PrismaService,
   ) {
-    try {
-      this.jwks = createRemoteJWKSet(new URL(process.env.OIDC_JWKS_URI || ''));
-    } catch (error) {
-      Logger.error('Failed to create JWKS set:', error);
+    if (process.env.OIDC_JWKS_URI) {
+      try {
+        this.jwks = createRemoteJWKSet(new URL(process.env.OIDC_JWKS_URI || ''));
+      } catch (error) {
+        Logger.error('Failed to create JWKS set:', error);
+      }
     }
   }
 


### PR DESCRIPTION
This pull request makes a small change to the initialization logic in the `LoginRequiredGuard` class. The constructor now only attempts to create a remote JWKS set if the `OIDC_JWKS_URI` environment variable is defined, improving stability and avoiding unnecessary errors.

* Only initialize the JWKS set in the constructor if `OIDC_JWKS_URI` is present, preventing errors when the environment variable is missing.