### PR TITLE
fix: remove invalid dash symbols before comments in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,16 +19,16 @@ services:
 
       # OIDC Configuration (example for Authentik)
       - OIDC_ISSUER="https://auth.chevrier.dev"
-      - # Endpoints for OIDC
+      # Endpoints for OIDC
       - OIDC_AUTHORIZATION_ENDPOINT="https://auth.chevrier.dev/authorize"
       - OIDC_TOKEN_ENDPOINT="https://auth.chevrier.dev/token"
       - OIDC_USERINFO_ENDPOINT="https://auth.chevrier.dev/userinfo"
       - OIDC_TOKEN_REVOKE_ENDPOINT="https://auth.chevrier.dev/revoke"
       - OIDC_END_SESSION_ENDPOINT="https://auth.chevrier.dev/end_session"
       - OIDC_JWKS_URI="https://auth.chevrier.dev/.well-known/jwks.json"
-      - # Callback URL for OIDC
+      # Callback URL for OIDC
       - OIDC_CALLBACK_URL="https://invoicerr.chevrier.dev/api/auth/callback"
-      - # Client ID and Secret for OIDC
+      # Client ID and Secret for OIDC
       - OIDC_CLIENT_ID="your-client-id"
       - OIDC_CLIENT_SECRET="your-client-secret"
 


### PR DESCRIPTION
The invalid use of dash (`-`) before comments in docker-compose.yml caused YAML parsing errors. This fix removes those dashes, ensuring the comments are treated correctly and the file adheres to valid YAML syntax.

## Error Log
```bash
$ docker compose config
services.invoicerr.environment.[10]: unexpected type <nil>
```

## Changes
- Removed the `-` prefix before comments to ensure they are treated as valid YAML comments.
- Verified the file is now parsable and works as expected with `docker-compose`.
This pull request makes a minor update to the `docker-compose.yml` file by cleaning up comment formatting for OIDC environment variables. No functional changes were made—only the removal of unnecessary dashes at the start of some comment lines to improve readability.