### PR TITLE
✨ feat: remove migrate deploy command from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN npm install
 
 COPY backend/. .
 
-RUN npx prisma migrate deploy 
 RUN npx prisma generate
 RUN npm run build
 


### PR DESCRIPTION
This pull request makes a minor change to the `Dockerfile` by removing the `npx prisma migrate deploy` command. This simplifies the build process by no longer running database migrations during the image build step.