### PR TITLE
♻️ refactor: update Docker image metadata and architecture

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -53,7 +53,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ env.REPO_NAME_LOWER }}:${{ env.IMAGE_TAG }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -79,7 +79,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ env.CACHE_REF }}
 
   build-arm64:
-    runs-on: ubuntu-22.04-arm64
+    runs-on: ubuntu-22.04-arm
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
This pull request updates the Docker publishing workflow configuration to improve image tagging and correct the runner specification for ARM builds.

**Improvements to Docker image publishing:**

* Updated the `docker/metadata-action` step to tag images with `${{ env.REPO_NAME_LOWER }}:${{ env.IMAGE_TAG }}` instead of using the repository name directly, allowing for more flexible and explicit image tagging.

**Build runner correction:**

* Changed the `runs-on` specification for the `build-arm64` job from `ubuntu-22.04-arm64` to `ubuntu-22.04-arm` to ensure the correct runner is used for ARM builds.