### PR TITLE
feat: optional client first name last name (#162)

### DIFF
--- a/backend/prisma/migrations/20250927133908_make_contact_names_optionals/migration.sql
+++ b/backend/prisma/migrations/20250927133908_make_contact_names_optionals/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - Changed the type of `fromCurrency` on the `CurrencyConversion` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `toCurrency` on the `CurrencyConversion` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."Client" ALTER COLUMN "contactFirstname" DROP NOT NULL,
+ALTER COLUMN "contactLastname" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "public"."CurrencyConversion" DROP COLUMN "fromCurrency",
+ADD COLUMN     "fromCurrency" TEXT NOT NULL,
+DROP COLUMN "toCurrency",
+ADD COLUMN     "toCurrency" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CurrencyConversion_fromCurrency_toCurrency_key" ON "public"."CurrencyConversion"("fromCurrency", "toCurrency");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -314,8 +314,8 @@ model Client {
   legalId          String? // Legal identification number (SIRET, EIN, etc.)
   VAT              String? // VAT number
   foundedAt        DateTime? // Date when the client company was founded
-  contactFirstname String
-  contactLastname  String
+  contactFirstname String?
+  contactLastname  String?
   contactEmail     String             @unique
   contactPhone     String?
   address          String

--- a/frontend/src/pages/(app)/clients/_components/client-upsert.tsx
+++ b/frontend/src/pages/(app)/clients/_components/client-upsert.tsx
@@ -41,8 +41,8 @@ export function ClientUpsert({ client, open, onOpenChange, onCreate }: ClientUps
             .optional(),
         currency: z.string().nullable().optional(),
         foundedAt: z.date().optional().refine((date) => !date || date <= new Date(), t("clients.upsert.validation.foundedAt.future")),
-        contactFirstname: z.string().min(1, t("clients.upsert.validation.contactFirstname.required")),
-        contactLastname: z.string().min(1, t("clients.upsert.validation.contactLastname.required")),
+        contactFirstname: z.string().optional(),
+        contactLastname: z.string().optional(),
         contactPhone: z
             .string()
             .min(8, t("clients.upsert.validation.contactPhone.minLength"))
@@ -141,7 +141,7 @@ export function ClientUpsert({ client, open, onOpenChange, onCreate }: ClientUps
                                     name="contactFirstname"
                                     render={({ field }) => (
                                         <FormItem>
-                                            <FormLabel required>{t("clients.upsert.fields.contactFirstname.label")}</FormLabel>
+                                            <FormLabel>{t("clients.upsert.fields.contactFirstname.label")}</FormLabel>
                                             <FormControl>
                                                 <Input {...field} placeholder={t("clients.upsert.fields.contactFirstname.placeholder")} />
                                             </FormControl>
@@ -154,7 +154,7 @@ export function ClientUpsert({ client, open, onOpenChange, onCreate }: ClientUps
                                     name="contactLastname"
                                     render={({ field }) => (
                                         <FormItem>
-                                            <FormLabel required>{t("clients.upsert.fields.contactLastname.label")}</FormLabel>
+                                            <FormLabel>{t("clients.upsert.fields.contactLastname.label")}</FormLabel>
                                             <FormControl>
                                                 <Input {...field} placeholder={t("clients.upsert.fields.contactLastname.placeholder")} />
                                             </FormControl>

--- a/frontend/src/pages/(app)/clients/_components/client-view.tsx
+++ b/frontend/src/pages/(app)/clients/_components/client-view.tsx
@@ -33,12 +33,14 @@ export function ClientViewDialog({ client, onOpenChange }: ClientViewDialogProps
                             <p className="text-sm text-muted-foreground">{t("clients.view.fields.companyName")}</p>
                             <p className="font-medium">{client?.name || "—"}</p>
                         </div>
+                        {(!!client?.contactFirstname || !!client?.contactLastname) && (
                         <div className="w-fit">
                             <p className="text-sm text-muted-foreground">{t("clients.view.fields.contactPerson")}</p>
                             <p className="font-medium">
-                                {client?.contactFirstname} {client?.contactLastname}
+                                    {client?.contactFirstname || ''} {client?.contactLastname || ''}
                             </p>
                         </div>
+                        )}
                     </div>
 
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-y-4 gap-x-8 bg-muted/50 p-4 rounded-lg w-full">

--- a/frontend/src/pages/(app)/clients/index.tsx
+++ b/frontend/src/pages/(app)/clients/index.tsx
@@ -32,8 +32,8 @@ export default function Clients() {
         clients?.clients.filter(
             (client) =>
                 client.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                client.contactFirstname.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                client.contactLastname.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                client.contactFirstname?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                client.contactLastname?.toLowerCase().includes(searchTerm.toLowerCase()) ||
                 client.contactEmail.toLowerCase().includes(searchTerm.toLowerCase()),
         ) || []
 

--- a/frontend/src/types/client.ts
+++ b/frontend/src/types/client.ts
@@ -5,8 +5,8 @@ export interface Client {
     legalId?: string;
     VAT?: string;
     foundedAt?: Date;
-    contactFirstname: string;
-    contactLastname: string;
+    contactFirstname?: string;
+    contactLastname?: string;
     contactEmail: string;
     contactPhone?: string;
     address?: string;


### PR DESCRIPTION
This pull request makes the contact first name and last name fields for clients optional throughout the backend and frontend. It updates the database schema, Prisma models, validation logic, UI rendering, and search functionality to support clients without a contact name.

**Database and schema changes:**

* Made `contactFirstname` and `contactLastname` optional (`NULLABLE`) in the `Client` table in the database and updated the Prisma schema accordingly. [[1]](diffhunk://#diff-4938f94277aa7a64b8b764aceccddbc9f7390e13e7f1f204f818327069cfd25cR1-R19) [[2]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfL317-R318)
* Modified the `CurrencyConversion` table to change the type of `fromCurrency` and `toCurrency` columns to `TEXT` and recreated them, also adding a unique index.

**Frontend and validation updates:**

* Updated the client upsert form validation to make `contactFirstname` and `contactLastname` optional, and removed the "required" indicator from their labels. [[1]](diffhunk://#diff-773cd1dd4b231c620a1a8267c5164fb1e657d92b3c97a59bac46ec503f68a6cbL44-R45) [[2]](diffhunk://#diff-773cd1dd4b231c620a1a8267c5164fb1e657d92b3c97a59bac46ec503f68a6cbL144-R144) [[3]](diffhunk://#diff-773cd1dd4b231c620a1a8267c5164fb1e657d92b3c97a59bac46ec503f68a6cbL157-R157)
* Updated the `Client` TypeScript interface to make `contactFirstname` and `contactLastname` optional.

**UI and search improvements:**

* Updated the client view dialog to only show the contact person section if either `contactFirstname` or `contactLastname` is present.
* Adjusted the clients search functionality to handle cases where `contactFirstname` or `contactLastname` may be missing.