### PR TITLE
🌐 i18n: Update webhook event instructions in French, English, and Spanish translations

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -1640,7 +1640,7 @@
         "step1": "1. Gehen Sie zu Ihrem Documenso-Admin-Panel",
         "step2": "2. Konfigurieren Sie die Webhook-URL",
         "step3": "3. Konfigurieren Sie das Webhook-Secret",
-        "step4": "4. Aktivieren Sie die folgenden Ereignisse: document.signed (mindestens erforderlich)",
+        "step4": "4. Aktivieren Sie die folgenden Ereignisse: document.signed, document.completed (mindestens erforderlich)",
         "step5": "5. Zusätzliche Ereignisse, die Sie aktivieren können: document.pending, document.completed, document.rejected"
       }
     },

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1640,7 +1640,7 @@
                 "step1": "1. Go to your Documenso admin panel",
                 "step2": "2. Configure webhook URL",
                 "step3": "3. Configure webhook secret",
-                "step4": "4. Enable the following events: document.signed (minimum required)",
+                "step4": "4. Enable the following events: document.signed, document.completed (minimum required)",
                 "step5": "5. Additional events you may want to enable: document.pending, document.completed, document.rejected"
             }
         },

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -1640,7 +1640,7 @@
                 "step1": "1. Accede a tu panel de administración de Documenso",
                 "step2": "2. Configura la URL del webhook",
                 "step3": "3. Configura el secreto del webhook",
-                "step4": "4. Activa los siguientes eventos: document.signed (mínimo requerido)",
+                "step4": "4. Activa los siguientes eventos: document.signed, document.completed (mínimo requerido)",
                 "step5": "5. Eventos adicionales que puedes activar: document.pending, document.completed, document.rejected"
             }
         },

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1644,7 +1644,7 @@
                 "step1": "1. Accédez à votre panneau d'administration Documenso",
                 "step2": "2. Configurez l'URL du webhook",
                 "step3": "3. Configurez le secret du webhook",
-                "step4": "4. Activez les événements suivants : document.signed (minimum requis)",
+                "step4": "4. Activez les événements suivants : document.signed, document.completed (minimum requis)",
                 "step5": "5. Événements supplémentaires que vous pouvez activer : document.pending, document.completed, document.rejected"
             }
         },


### PR DESCRIPTION
This pull request updates the webhook configuration instructions in the localization files for German, English, Spanish, and French. The main change is the addition of `document.completed` to the list of minimum required events for webhook activation, ensuring users enable both `document.signed` and `document.completed` events.

Localization updates for webhook instructions:

* German (`frontend/src/locales/de/translation.json`): Added `document.completed` to the minimum required events in step 4.
* English (`frontend/src/locales/en/translation.json`): Added `document.completed` to the minimum required events in step 4.
* Spanish (`frontend/src/locales/es/translation.json`): Added `document.completed` to the minimum required events in step 4.
* French (`frontend/src/locales/fr/translation.json`): Added `document.completed` to the minimum required events in step 4.