### PR TITLE
Add `baseUrl` configuration

### DIFF
--- a/backend/src/lib/auth.ts
+++ b/backend/src/lib/auth.ts
@@ -113,6 +113,7 @@ const userAfterCreateHook = async (user) => {
 };
 
 export const auth = betterAuth({    
+    baseUrl: process.env.APP_URL || 'http://localhost:3000',
     trustedOrigins: ['http://localhost:5173', process.env.APP_URL, ...(process.env.CORS_ORIGINS?.split(',').map(o => o.trim()) || [])].filter((origin): origin is string => typeof origin === 'string'),
     database: prismaAdapter(prisma, {
         provider: "postgresql",


### PR DESCRIPTION
I spent some time trying to diagnose the reasons why the OIDC didn't fully work, I finally managed to use Authelia with it but I noticed either I have to set the `BETTER_AUTH_URL` that's set in the backend Dockerfile or following the documentation of `better-auth` go with setting this value in the `betterAuth` constructor like mentioned here

https://www.better-auth.com/docs/reference/options#baseurl

I did not test it, but I believe this should be enough