### PR TITLE
fix: show error toast when sending invoice/receipt email fails

### DIFF
--- a/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
@@ -153,8 +153,12 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
 
         const handleSendInvoiceByEmail = (invoiceId: string) => {
             triggerSendInvoiceByEmail({ id: invoiceId })
-                .then(() => {
-                    toast.success(t("invoices.list.messages.sendByEmailSuccess"))
+                .then((result) => {
+                    if (result) {
+                        toast.success(t("invoices.list.messages.sendByEmailSuccess"))
+                    } else {
+                        toast.error(t("invoices.list.messages.sendByEmailError"))
+                    }
                 })
                 .catch((error) => {
                     console.error("Error sending invoice by email:", error)

--- a/frontend/src/pages/(app)/receipts/_components/receipt-list.tsx
+++ b/frontend/src/pages/(app)/receipts/_components/receipt-list.tsx
@@ -89,9 +89,13 @@ export const ReceiptList = forwardRef<ReceiptListHandle, ReceiptListProps>(
 
         function handleSendToClient(receipt: Receipt) {
             triggerSendToClient({ id: receipt.id })
-                .then(() => {
-                    toast.success(t("receipts.list.messages.emailSent"))
-                    mutate && mutate()
+                .then((result) => {
+                    if (result) {
+                        toast.success(t("receipts.list.messages.emailSent"))
+                        mutate && mutate()
+                    } else {
+                        toast.error(t("receipts.list.messages.emailError"))
+                    }
                 })
                 .catch((error) => {
                     console.error("Error sending receipt to client:", error)


### PR DESCRIPTION
## Problem
When an email send failed (e.g. SMTP error), the UI still showed a green
success toast (#222). `usePost`'s `trigger` resolves to `null` on failure
instead of rejecting, so the `.then(() => toast.success(...))` handlers always
ran.

## Fix
Check the result before showing success in the email-send handlers, mirroring
the existing pattern already used for quote signature sending:
- invoice "send by email"
- receipt "send to client"

On a falsy result, an error toast is shown instead. No change to the shared
`usePost` hook, so other flows are unaffected.

Closes #222