### PR TITLE
Fix/list pages ux

### DIFF
--- a/backend/docker-compose.local.yml
+++ b/backend/docker-compose.local.yml
@@ -2,14 +2,14 @@
 
   services:
     database-postgresql:
-      image: postgres
+      image: postgres:15
       restart: always
       environment:
         POSTGRES_DB: ${POSTGRES_DB}
         POSTGRES_USER: ${POSTGRES_USER}
         POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       ports:
-        - '5432:5432'
+        - '5431:5432'
       volumes:
         - docker-postgres:/var/lib/postgresql/data
 

--- a/backend/src/plugins/signing/utils.ts
+++ b/backend/src/plugins/signing/utils.ts
@@ -1,4 +1,4 @@
-import { PDFDocument } from "@fin.cx/einvoice/dist_ts/plugins";
+import { PDFDocument } from "pdf-lib";
 
 export async function uploadQuoteFileToUrl(fileBuffer: Uint8Array, uploadUrl: string) {
     fileBuffer = Buffer.isBuffer(fileBuffer) ? fileBuffer : Buffer.from(fileBuffer)

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "NodeNext",
-    "declaration": true,
+    "declaration": false,
     "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   invoicerr:
-    #image: ghcr.io/invoicerr-app/invoicerr:latest
-    build: .
+    image: ghcr.io/invoicerr-app/invoicerr:latest
     ports:
       - "80:80"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   invoicerr:
-    image: ghcr.io/invoicerr-app/invoicerr:latest
+    #image: ghcr.io/invoicerr-app/invoicerr:latest
+    build: .
     ports:
       - "80:80"
     environment:

--- a/e2e/cypress/e2e/10-recurring-invoices.cy.ts
+++ b/e2e/cypress/e2e/10-recurring-invoices.cy.ts
@@ -2,17 +2,28 @@ beforeEach(() => {
     cy.login();
 });
 
+function openRecurringInvoiceDialog() {
+    cy.visit('/invoices');
+    cy.wait(2000);
+
+    cy.get('[data-cy="invoice-add-button"]').click();
+    cy.get('[data-cy="invoice-dialog"]', { timeout: 5000 }).should('be.visible');
+
+    cy.get('[data-cy="invoice-tab-recurring"]').click();
+}
+
+function fillRecurringItem(description: string, quantity: string, unitPrice: string, vatRate: string) {
+    cy.contains('button', /Add Item|Ajouter/i).click();
+    cy.get('[name="items.0.description"]').type(description, { force: true });
+    cy.get('[name="items.0.quantity"]').clear({ force: true }).type(quantity, { force: true });
+    cy.get('[name="items.0.unitPrice"]').clear({ force: true }).type(unitPrice, { force: true });
+    cy.get('[name="items.0.vatRate"]').clear({ force: true }).type(vatRate, { force: true });
+}
+
 describe('Recurring Invoices E2E', () => {
     describe('Create Recurring Invoices', () => {
         it('creates a monthly recurring invoice', () => {
-            cy.visit('/invoices');
-            cy.wait(2000);
-
-            // Find the Recurring Invoices section and click Add
-            cy.contains(/recurring|récurrent/i).closest('.rounded-xl').find('button').contains(/add|new|créer|ajouter/i).click({ force: true });
-            cy.wait(500);
-
-            cy.get('[data-cy="recurring-invoice-dialog"]', { timeout: 5000 }).should('be.visible');
+            openRecurringInvoiceDialog();
 
             cy.get('[data-cy="recurring-invoice-client-select"] button').first().click();
             cy.wait(300);
@@ -22,26 +33,16 @@ describe('Recurring Invoices E2E', () => {
             cy.contains('label', /frequency|fréquence/i).parent().find('button').click({ force: true });
             cy.get('[role="option"]').eq(2).click();
 
-            cy.contains('button', /Add Item|Ajouter/i).click();
-            cy.get('[name="items.0.description"]').type('Monthly Retainer', { force: true });
-            cy.get('[name="items.0.quantity"]').clear({ force: true }).type('1', { force: true });
-            cy.get('[name="items.0.unitPrice"]').clear({ force: true }).type('1500', { force: true });
-            cy.get('[name="items.0.vatRate"]').clear({ force: true }).type('20', { force: true });
+            fillRecurringItem('Monthly Retainer', '1', '1500', '20');
 
-            cy.get('[data-cy="recurring-invoice-submit"]').click();
+            cy.get('[data-cy="invoice-submit"]').click();
 
-            cy.get('[data-cy="recurring-invoice-dialog"]').should('not.exist');
+            cy.get('[data-cy="invoice-dialog"]').should('not.exist');
             cy.wait(2000);
         });
 
         it('creates a weekly recurring invoice', () => {
-            cy.visit('/invoices');
-            cy.wait(2000);
-
-            cy.contains(/recurring|récurrent/i).closest('.rounded-xl').find('button').contains(/add|new|créer|ajouter/i).click({ force: true });
-            cy.wait(500);
-
-            cy.get('[data-cy="recurring-invoice-dialog"]', { timeout: 5000 }).should('be.visible');
+            openRecurringInvoiceDialog();
 
             cy.get('[data-cy="recurring-invoice-client-select"] button').first().click();
             cy.wait(300);
@@ -51,99 +52,75 @@ describe('Recurring Invoices E2E', () => {
             cy.contains('label', /frequency|fréquence/i).parent().find('button').click({ force: true });
             cy.get('[role="option"]').eq(0).click();
 
-            cy.contains('button', /Add Item|Ajouter/i).click();
-            cy.get('[name="items.0.description"]').type('Weekly Maintenance', { force: true });
-            cy.get('[name="items.0.quantity"]').clear({ force: true }).type('4', { force: true });
-            cy.get('[name="items.0.unitPrice"]').clear({ force: true }).type('250', { force: true });
-            cy.get('[name="items.0.vatRate"]').clear({ force: true }).type('20', { force: true });
+            fillRecurringItem('Weekly Maintenance', '4', '250', '20');
 
-            cy.get('[data-cy="recurring-invoice-submit"]').click();
+            cy.get('[data-cy="invoice-submit"]').click();
 
-            cy.get('[data-cy="recurring-invoice-dialog"]').should('not.exist');
+            cy.get('[data-cy="invoice-dialog"]').should('not.exist');
             cy.wait(2000);
         });
     });
 
     describe('Validation Errors', () => {
         it('shows error when no client is selected', () => {
-            cy.visit('/invoices');
-            cy.wait(2000);
-
-            cy.contains(/recurring|récurrent/i).closest('.rounded-xl').find('button').contains(/add|new|créer|ajouter/i).click({ force: true });
-            cy.wait(500);
-
-            cy.get('[data-cy="recurring-invoice-dialog"]', { timeout: 5000 }).should('be.visible');
+            openRecurringInvoiceDialog();
 
             cy.contains('label', /frequency|fréquence/i).parent().find('button').click({ force: true });
             cy.get('[role="option"]').eq(0).click();
 
-            cy.contains('button', /Add Item|Ajouter/i).click();
-            cy.get('[name="items.0.description"]').type('Test Item', { force: true });
-            cy.get('[name="items.0.quantity"]').clear({ force: true }).type('1', { force: true });
-            cy.get('[name="items.0.unitPrice"]').clear({ force: true }).type('100', { force: true });
-            cy.get('[name="items.0.vatRate"]').clear({ force: true }).type('0', { force: true });
+            fillRecurringItem('Test Item', '1', '100', '0');
 
-            cy.get('[data-cy="recurring-invoice-submit"]').click();
-            cy.get('[data-cy="recurring-invoice-dialog"]').should('be.visible');
+            cy.get('[data-cy="invoice-submit"]').click();
+            cy.get('[data-cy="invoice-dialog"]').should('be.visible');
             cy.contains(/client|required|requis/i);
         });
 
         it('shows error when no frequency is selected', () => {
-            cy.visit('/invoices');
-            cy.wait(2000);
-
-            cy.contains(/recurring|récurrent/i).closest('.rounded-xl').find('button').contains(/add|new|créer|ajouter/i).click({ force: true });
-            cy.wait(500);
-
-            cy.get('[data-cy="recurring-invoice-dialog"]', { timeout: 5000 }).should('be.visible');
+            openRecurringInvoiceDialog();
 
             cy.get('[data-cy="recurring-invoice-client-select"] button').first().click();
             cy.wait(300);
             cy.get('[data-cy="recurring-invoice-client-select-options"]').should('be.visible');
             cy.get('[data-cy="recurring-invoice-client-select-options"] button').first().click();
 
-            cy.contains('button', /Add Item|Ajouter/i).click();
-            cy.get('[name="items.0.description"]').type('Test Item', { force: true });
-            cy.get('[name="items.0.quantity"]').clear({ force: true }).type('1', { force: true });
-            cy.get('[name="items.0.unitPrice"]').clear({ force: true }).type('100', { force: true });
-            cy.get('[name="items.0.vatRate"]').clear({ force: true }).type('0', { force: true });
+            fillRecurringItem('Test Item', '1', '100', '0');
 
-            cy.get('[data-cy="recurring-invoice-submit"]').click();
-            cy.get('[data-cy="recurring-invoice-dialog"]').should('be.visible');
+            cy.get('[data-cy="invoice-submit"]').click();
+            cy.get('[data-cy="invoice-dialog"]').should('be.visible');
             cy.contains(/frequency|fréquence|required|requis/i);
         });
     });
 
     describe('View Recurring Invoices', () => {
-        it('views recurring invoices list', () => {
+        it('views recurring invoices in the table', () => {
             cy.visit('/invoices');
             cy.wait(2000);
 
-            cy.contains(/recurring|récurrent/i, { timeout: 10000 }).click();
+            cy.get('[data-cy="invoice-filter-recurring"]').click();
             cy.wait(1000);
 
             cy.get('body').then($body => {
-                if ($body.find('[class*="Card"], [class*="card"]').length > 0) {
-                    cy.get('[class*="Card"], [class*="card"]').should('have.length.at.least', 1);
+                if ($body.find('[data-cy="invoice-row"]').length > 0) {
+                    cy.get('[data-cy="invoice-row"]').should('have.length.at.least', 1);
                 }
             });
         });
     });
 
     describe('Delete Recurring Invoice', () => {
-        it('deletes a recurring invoice', () => {
+        it('deletes a generated recurring invoice', () => {
             cy.visit('/invoices');
             cy.wait(2000);
 
-            cy.contains(/recurring|récurrent/i, { timeout: 10000 }).click();
+            cy.get('[data-cy="invoice-filter-recurring"]').click();
             cy.wait(1000);
 
             cy.get('body').then($body => {
-                const deleteButtons = $body.find('button[tooltip*="Delete"], button[tooltip*="Supprimer"]');
+                const deleteButtons = $body.find('[data-cy="invoice-delete-button"]');
                 if (deleteButtons.length > 0) {
                     cy.wrap(deleteButtons).first().click({ force: true });
-                    cy.get('[role="alertdialog"], [role="dialog"]').within(() => {
-                        cy.contains('button', /delete|confirm|supprimer|confirmer/i).click();
+                    cy.get('[role="dialog"]').within(() => {
+                        cy.contains('button', /delete|supprimer/i).click();
                     });
                     cy.wait(2000);
                 }

--- a/frontend/src/components/onboarding.tsx
+++ b/frontend/src/components/onboarding.tsx
@@ -24,6 +24,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 interface OnBoardingProps {
   isLoading?: boolean
   isOpen?: boolean
+  onOpenChange?: (open: boolean) => void
 }
 
 export interface OnBoardingData {
@@ -54,6 +55,7 @@ export interface OnBoardingData {
 export default function OnBoarding({
   isLoading: externalLoading,
   isOpen = true,
+  onOpenChange,
 }: OnBoardingProps) {
   const { t } = useTranslation()
   const STEPS = [
@@ -226,6 +228,7 @@ export default function OnBoarding({
     try {
       await trigger(values)
       toast.success(t("settings.company.messages.updateSuccess"))
+      onOpenChange?.(false)
     } catch (error) {
       console.error("Error during onboarding:", error)
       toast.error(t("settings.company.messages.updateError"))
@@ -265,8 +268,8 @@ export default function OnBoarding({
   const loading = isLoading || externalLoading
 
   return (
-    <Dialog open={isOpen}>
-      <DialogContent className="!max-w-[50vw] max-h-[90vh] overflow-y-auto p-8" showCloseButton={false} data-cy="onboarding-dialog">
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="!max-w-[50vw] max-h-[90vh] overflow-y-auto p-8" showCloseButton data-cy="onboarding-dialog">
         <DialogHeader>
           <DialogTitle>{t("settings.company.title")}</DialogTitle>
           <DialogDescription>{t("settings.company.description")}</DialogDescription>

--- a/frontend/src/components/page-header-provider.tsx
+++ b/frontend/src/components/page-header-provider.tsx
@@ -1,0 +1,46 @@
+import { createContext, useCallback, useContext, useState } from "react"
+
+import type React from "react"
+
+type PageHeaderValue = {
+    title: React.ReactNode
+    icon: React.ReactNode
+    actions: React.ReactNode
+}
+
+type PageHeaderSetter = (title: React.ReactNode, icon?: React.ReactNode, actions?: React.ReactNode) => void
+
+const PageHeaderStateContext = createContext<PageHeaderValue | undefined>(undefined)
+const PageHeaderSetterContext = createContext<PageHeaderSetter | undefined>(undefined)
+
+export function PageHeaderProvider({ children }: { children: React.ReactNode }) {
+    const [value, setValue] = useState<PageHeaderValue>({ title: null, icon: null, actions: null })
+
+    const setPageHeader = useCallback<PageHeaderSetter>((title, icon, actions) => {
+        setValue({ title, icon: icon ?? null, actions: actions ?? null })
+    }, [])
+
+    return (
+        <PageHeaderSetterContext.Provider value={setPageHeader}>
+            <PageHeaderStateContext.Provider value={value}>
+                {children}
+            </PageHeaderStateContext.Provider>
+        </PageHeaderSetterContext.Provider>
+    )
+}
+
+export const usePageHeaderContext = () => {
+    const context = useContext(PageHeaderStateContext)
+
+    if (context === undefined) throw new Error("usePageHeaderContext must be used within a PageHeaderProvider")
+
+    return context
+}
+
+export const useSetPageHeader = () => {
+    const context = useContext(PageHeaderSetterContext)
+
+    if (context === undefined) throw new Error("useSetPageHeader must be used within a PageHeaderProvider")
+
+    return context
+}

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -136,7 +136,7 @@ export function Sidebar() {
                         <SidebarMenuButton
                             size="lg"
                             className="cursor-pointer"
-                            onClick={() => setOnboardingOpen(true)}
+                            onClick={() => navigate("/settings/company")}
                             data-cy="sidebar-company-button"
                         >
                             <div className="bg-accent text-accent-foreground flex aspect-square size-8 items-center justify-center rounded-lg">

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -36,6 +36,8 @@ import OnBoarding from "./onboarding"
 import type React from "react"
 import { Skeleton } from "./ui/skeleton"
 import { authClient } from "@/lib/auth"
+import { useEffect, useRef, useState } from "react"
+
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useSse } from "@/hooks/use-fetch"
 import { useTheme } from "./theme-provider"
@@ -52,6 +54,21 @@ export function Sidebar() {
     const { setTheme } = useTheme()
     const { data: company, loading: companyLoading } = useSse<Company>("/api/company/info/sse")
     const navigate = useNavigate()
+
+    const [onboardingOpen, setOnboardingOpen] = useState(false)
+    const hasAutoOpenedOnboarding = useRef(false)
+
+    useEffect(() => {
+        if (
+            !hasAutoOpenedOnboarding.current &&
+            !companyLoading &&
+            (!company || !company.name) &&
+            location.pathname !== "/settings/company"
+        ) {
+            hasAutoOpenedOnboarding.current = true
+            setOnboardingOpen(true)
+        }
+    }, [companyLoading, company, location.pathname])
 
     const items: { title: string; icon: React.ReactNode; url: string, dataCy: string }[] = [
         {
@@ -111,21 +128,24 @@ export function Sidebar() {
 
     return (
         <RootSidebar collapsible="icon">
-            <OnBoarding isOpen={!companyLoading && (!company || !company.name) && location.pathname !== "/settings/company"} />
+            <OnBoarding isOpen={onboardingOpen} onOpenChange={setOnboardingOpen} />
 
             <SidebarHeader className="px-2">
                 <SidebarMenu>
                     <SidebarMenuItem>
-                        <SidebarMenuButton size="lg" asChild>
-                            <section className="flex items-center gap-2">
-                                <div className="bg-accent text-accent-foreground flex aspect-square size-8 items-center justify-center rounded-lg">
-                                    <Building2 className="size-4" />
-                                </div>
-                                <div className="grid flex-1 text-left text-sm leading-tight">
-                                    <span className="truncate font-medium">{company?.name}</span>
-                                    <span className="truncate text-xs">{t("sidebar.company.plan")}</span>
-                                </div>
-                            </section>
+                        <SidebarMenuButton
+                            size="lg"
+                            className="cursor-pointer"
+                            onClick={() => setOnboardingOpen(true)}
+                            data-cy="sidebar-company-button"
+                        >
+                            <div className="bg-accent text-accent-foreground flex aspect-square size-8 items-center justify-center rounded-lg">
+                                <Building2 className="size-4" />
+                            </div>
+                            <div className="grid flex-1 text-left text-sm leading-tight">
+                                <span className="truncate font-medium">{company?.name}</span>
+                                <span className="truncate text-xs">{t("sidebar.company.plan")}</span>
+                            </div>
                         </SidebarMenuButton>
                     </SidebarMenuItem>
                 </SidebarMenu>

--- a/frontend/src/hooks/use-page-header.ts
+++ b/frontend/src/hooks/use-page-header.ts
@@ -1,0 +1,13 @@
+import { useEffect } from "react"
+
+import type React from "react"
+import { useSetPageHeader } from "@/components/page-header-provider"
+
+export function usePageHeader(title: React.ReactNode, icon?: React.ReactNode, actions?: React.ReactNode) {
+    const setPageHeader = useSetPageHeader()
+
+    useEffect(() => {
+        setPageHeader(title, icon, actions)
+        return () => setPageHeader(null)
+    })
+}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -216,6 +216,7 @@
         "filters": {
             "all": "All",
             "draft": "Draft",
+            "sent": "Sent",
             "signed": "Signed"
         },
         "emptyState": {
@@ -413,7 +414,8 @@
         "statusFilters": {
             "all": "All",
             "sent": "Sent",
-            "paid": "Paid"
+            "paid": "Paid",
+            "unpaid": "Unpaid"
         },
         "emptyState": {
             "noInvoices": "No invoices yet",
@@ -476,6 +478,10 @@
             "title": {
                 "create": "Create New Invoice",
                 "edit": "Edit Invoice"
+            },
+            "tabs": {
+                "invoice": "Invoice",
+                "recurring": "Recurring Invoice"
             },
             "form": {
                 "quote": {
@@ -1761,7 +1767,11 @@
         "noData": "No data available for the selected period.",
         "controls": {
             "year": "Year",
-            "range": "Year range"
+            "range": "Year range",
+            "tabs": {
+                "monthly": "By month",
+                "yearly": "By year"
+            }
         },
         "monthly": {
             "title": "Monthly statistics"

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1,4 +1,9 @@
 {
+    "errorBoundary": {
+        "title": "Something went wrong",
+        "description": "An unexpected error occurred while rendering this page. You can try reloading the page.",
+        "reload": "Reload page"
+    },
     "clients": {
         "header": {
             "subtitle": "Manage your clients",
@@ -208,6 +213,11 @@
             "draft": "Draft",
             "signed": "Signed"
         },
+        "filters": {
+            "all": "All",
+            "draft": "Draft",
+            "signed": "Signed"
+        },
         "emptyState": {
             "noQuotes": "No quotes yet",
             "noResults": "No quotes found",
@@ -390,8 +400,18 @@
         "actions": {
             "addNew": "Add New Invoice"
         },
+        "filters": {
+            "all": "All",
+            "oneTime": "One-time",
+            "recurring": "Recurring"
+        },
         "stats": {
             "total": "Total Invoices",
+            "sent": "Sent",
+            "paid": "Paid"
+        },
+        "statusFilters": {
+            "all": "All",
             "sent": "Sent",
             "paid": "Paid"
         },
@@ -408,13 +428,16 @@
                 "sent": "Sent",
                 "unpaid": "Unpaid",
                 "overdue": "Overdue",
-                "paid": "Paid"
+                "paid": "Paid",
+                "upcoming": "Upcoming"
             },
             "item": {
                 "title": "Invoice {{number}} {{title}}",
+                "upcomingTitle": "Next invoice - {{client}}",
                 "client": "Client",
                 "issued": "Issued",
                 "due": "Due",
+                "nextInvoiceDate": "Next invoice on",
                 "payment": "Payment",
                 "totalHT": "Total (excl. VAT)",
                 "totalTTC": "Total (incl. VAT)"

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -217,6 +217,7 @@
         "filters": {
             "all": "Tous",
             "draft": "Brouillon",
+            "sent": "Envoyé",
             "signed": "Signés"
         },
         "emptyState": {
@@ -414,7 +415,8 @@
         "statusFilters": {
             "all": "Toutes",
             "sent": "Envoyées",
-            "paid": "Payées"
+            "paid": "Payées",
+            "unpaid": "Impayées"
         },
         "emptyState": {
             "noInvoices": "Aucune facture pour le moment",
@@ -477,6 +479,10 @@
             "title": {
                 "create": "Créer une nouvelle facture",
                 "edit": "Modifier la facture"
+            },
+            "tabs": {
+                "invoice": "Facture",
+                "recurring": "Facture récurrente"
             },
             "form": {
                 "quote": {
@@ -903,6 +909,7 @@
         "empty": "Aucun moyen de paiement disponible pour le moment."
     },
     "settings": {
+        "title": "Paramètres",
         "tabs": {
             "company": "Entreprise",
             "pdfTemplates": "Modèles PDF",
@@ -1761,7 +1768,11 @@
         "noData": "Aucune donnée disponible pour la période sélectionnée.",
         "controls": {
             "year": "Année",
-            "range": "Plage d'années"
+            "range": "Plage d'années",
+            "tabs": {
+                "monthly": "Par mois",
+                "yearly": "Par années"
+            }
         },
         "monthly": {
             "title": "Statistiques mensuelles"

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1,4 +1,9 @@
 {
+    "errorBoundary": {
+        "title": "Une erreur est survenue",
+        "description": "Une erreur inattendue s'est produite lors de l'affichage de cette page. Vous pouvez essayer de recharger la page.",
+        "reload": "Recharger la page"
+    },
     "clients": {
         "header": {
             "subtitle": "Gérez vos clients",
@@ -209,6 +214,11 @@
             "draft": "Brouillon",
             "signed": "Signés"
         },
+        "filters": {
+            "all": "Tous",
+            "draft": "Brouillon",
+            "signed": "Signés"
+        },
         "emptyState": {
             "noQuotes": "Aucun devis pour le moment",
             "noResults": "Aucun devis trouvé",
@@ -391,8 +401,18 @@
         "actions": {
             "addNew": "Ajouter une nouvelle facture"
         },
+        "filters": {
+            "all": "Toutes",
+            "oneTime": "Ponctuelles",
+            "recurring": "Récurrentes"
+        },
         "stats": {
             "total": "Total des factures",
+            "sent": "Envoyées",
+            "paid": "Payées"
+        },
+        "statusFilters": {
+            "all": "Toutes",
             "sent": "Envoyées",
             "paid": "Payées"
         },
@@ -409,13 +429,16 @@
                 "sent": "Envoyée",
                 "unpaid": "Impayée",
                 "overdue": "En retard",
-                "paid": "Payée"
+                "paid": "Payée",
+                "upcoming": "À venir"
             },
             "item": {
                 "title": "Facture {{number}} {{title}}",
+                "upcomingTitle": "Prochaine facture - {{client}}",
                 "client": "Client",
                 "issued": "Émise le",
                 "due": "Échéance",
+                "nextInvoiceDate": "Prochaine facture le",
                 "payment": "Paiement",
                 "totalHT": "Total HT",
                 "totalTTC": "Total TTC"

--- a/frontend/src/pages/(app)/_layout.tsx
+++ b/frontend/src/pages/(app)/_layout.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Outlet, useLocation } from "react-router";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 
+import { PageHeaderProvider, usePageHeaderContext } from "@/components/page-header-provider";
 import { Sidebar } from "@/components/sidebar";
 import { authClient } from "@/lib/auth";
 
@@ -8,15 +9,59 @@ const ALLOWED_PATHS = [
     '/signature/[^/]+',
 ];
 
+const PageHeaderTitle = () => {
+    const { title } = usePageHeaderContext();
+
+    if (!title) return null;
+
+    return (
+        <div className="flex items-center gap-2">
+            <h1 className="text-lg font-semibold text-foreground">{title}</h1>
+        </div>
+    );
+};
+
+const PageHeaderActions = () => {
+    const { actions } = usePageHeaderContext();
+
+    if (!actions) return null;
+
+    return <div className="flex items-center gap-2 ml-auto">{actions}</div>;
+};
+
 const AuthenticatedLayout = () => {
     return (
         <SidebarProvider>
+            <PageHeaderProvider>
+                <section className="flex flex-col min-h-screen h-screen max-h-screen w-full max-w-screen overflow-y-auto overflow-x-hidden">
+                    <main className="flex flex-1 h-full w-full max-w-screen overflow-y-auto overflow-x-hidden">
+                        <Sidebar />
+                        <section className="flex flex-col flex-1 h-full w-full max-w-screen overflow-hidden">
+                            <header className="p-4 bg-header border-b flex items-center gap-4">
+                                <SidebarTrigger />
+                                <PageHeaderTitle />
+                                <PageHeaderActions />
+                            </header>
+                            <section className="h-full overflow-y-auto overflow-x-hidden">
+                                <Outlet />
+                            </section>
+                        </section>
+                    </main>
+                </section>
+            </PageHeaderProvider>
+        </SidebarProvider>
+    );
+};
+
+const UnauthenticatedLayout = () => {
+    return (
+        <PageHeaderProvider>
             <section className="flex flex-col min-h-screen h-screen max-h-screen w-full max-w-screen overflow-y-auto overflow-x-hidden">
                 <main className="flex flex-1 h-full w-full max-w-screen overflow-y-auto overflow-x-hidden">
-                    <Sidebar />
                     <section className="flex flex-col flex-1 h-full w-full max-w-screen overflow-hidden">
-                        <header className="p-4 bg-header border-b">
-                            <SidebarTrigger />
+                        <header className="p-4 bg-header border-b flex items-center gap-4">
+                            <PageHeaderTitle />
+                            <PageHeaderActions />
                         </header>
                         <section className="h-full overflow-y-auto overflow-x-hidden">
                             <Outlet />
@@ -24,22 +69,7 @@ const AuthenticatedLayout = () => {
                     </section>
                 </main>
             </section>
-        </SidebarProvider>
-    );
-};
-
-const UnauthenticatedLayout = () => {
-    return (
-        <section className="flex flex-col min-h-screen h-screen max-h-screen w-full max-w-screen overflow-y-auto overflow-x-hidden">
-            <main className="flex flex-1 h-full w-full max-w-screen overflow-y-auto overflow-x-hidden">
-                <section className="flex flex-col flex-1 h-full w-full max-w-screen overflow-hidden">
-                    <header className="p-4 bg-header border-b" />
-                    <section className="h-full overflow-y-auto overflow-x-hidden">
-                        <Outlet />
-                    </section>
-                </section>
-            </main>
-        </section>
+        </PageHeaderProvider>
     );
 };
 

--- a/frontend/src/pages/(app)/clients/index.tsx
+++ b/frontend/src/pages/(app)/clients/index.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card"
 import { Edit, Eye, Mail, MapPin, Phone, Plus, Search, Trash2, User, Users } from "lucide-react"
 
 import BetterPagination from "@/components/pagination"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import type { Client } from "@/types"
 import { ClientDeleteDialog } from "./_components/client-delete"
@@ -12,6 +13,8 @@ import { usePageHeader } from "@/hooks/use-page-header"
 import { useSse } from "@/hooks/use-fetch"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
+
+type ActiveFilter = "active" | "inactive" | undefined
 
 export default function Clients() {
     const { t } = useTranslation()
@@ -26,15 +29,24 @@ export default function Clients() {
     const [deleteClientDialog, setDeleteClientDialog] = useState<Client | null>(null)
 
     const [searchTerm, setSearchTerm] = useState("")
+    const [activeFilter, setActiveFilter] = useState<ActiveFilter>(undefined)
 
     const filteredClients =
         clients?.clients.filter(
             (client) =>
-                client.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                client.contactFirstname?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                client.contactLastname?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                client.contactEmail.toLowerCase().includes(searchTerm.toLowerCase()),
+                (client.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                    client.contactFirstname?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                    client.contactLastname?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                    client.contactEmail.toLowerCase().includes(searchTerm.toLowerCase())) &&
+                (!activeFilter ||
+                    (activeFilter === "active" && client.isActive) ||
+                    (activeFilter === "inactive" && !client.isActive)),
         ) || []
+
+    const activeCounts = {
+        active: clients?.clients.filter((c) => c.isActive).length || 0,
+        inactive: clients?.clients.filter((c) => !c.isActive).length || 0,
+    }
 
     function handleAddClick() {
         setCreateClientDialog(true)
@@ -88,10 +100,34 @@ export default function Clients() {
                             className="pl-10 w-full"
                         />
                     </div>
-                    <Button onClick={handleAddClick}>
-                        <Plus className="h-4 w-4 mr-0 md:mr-2" />
-                        <span className="hidden md:inline-flex">{t("clients.actions.addNew")}</span>
-                    </Button>
+                    <div className="flex items-center gap-2 sm:ml-auto">
+                        <div className="flex items-center gap-2">
+                            <Badge
+                                onClick={() => setActiveFilter(activeFilter === "active" ? undefined : "active")}
+                                variant="outline"
+                                className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${activeFilter === "active"
+                                    ? "bg-green-600 text-white font-semibold shadow-sm scale-105"
+                                    : "bg-green-50 text-green-700/70 hover:bg-green-100"
+                                    }`}
+                            >
+                                {t("clients.stats.active")} ({activeCounts.active})
+                            </Badge>
+                            <Badge
+                                onClick={() => setActiveFilter(activeFilter === "inactive" ? undefined : "inactive")}
+                                variant="outline"
+                                className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${activeFilter === "inactive"
+                                    ? "bg-gray-500 text-white font-semibold shadow-sm scale-105"
+                                    : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                                    }`}
+                            >
+                                {t("clients.stats.inactive")} ({activeCounts.inactive})
+                            </Badge>
+                        </div>
+                        <Button onClick={handleAddClick}>
+                            <Plus className="h-4 w-4 mr-0 md:mr-2" />
+                            <span className="hidden md:inline-flex">{t("clients.actions.addNew")}</span>
+                        </Button>
+                    </div>
                 </CardHeader>
 
                 <CardContent className="p-0">

--- a/frontend/src/pages/(app)/clients/index.tsx
+++ b/frontend/src/pages/(app)/clients/index.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card"
 import { Edit, Eye, Mail, MapPin, Phone, Plus, Search, Trash2, User, Users } from "lucide-react"
 
 import BetterPagination from "@/components/pagination"
@@ -8,6 +8,7 @@ import { ClientDeleteDialog } from "./_components/client-delete"
 import { ClientUpsert } from "./_components/client-upsert"
 import { ClientViewDialog } from "./_components/client-view"
 import { Input } from "@/components/ui/input"
+import { usePageHeader } from "@/hooks/use-page-header"
 import { useSse } from "@/hooks/use-fetch"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -51,6 +52,8 @@ export default function Clients() {
         setDeleteClientDialog(client)
     }
 
+    usePageHeader(t("sidebar.navigation.clients"))
+
     const emptyState = (
         <div className="text-center py-12">
             <Users className="mx-auto h-12 w-12 text-gray-400" />
@@ -73,24 +76,10 @@ export default function Clients() {
 
     return (
         <div className="max-w-7xl mx-auto space-y-6 p-6">
-            <div className="flex flex-col lg:flex-row items-start lg:items-center gap-4 lg:gap-0 lg:justify-between">
-                <div className="flex items-center space-x-3">
-                    <div className="p-2 bg-blue-100 rounded-lg">
-                        <Users className="h-5 w-5 text-blue-600" />
-                    </div>
-                    <div>
-                        <div className="text-sm text-primary">{t("clients.header.subtitle")}</div>
-                        <div className="font-medium text-foreground">
-                            {t("clients.header.count", {
-                                count: filteredClients.length,
-                                found: searchTerm ? t("clients.header.found") : "",
-                            })}
-                        </div>
-                    </div>
-                </div>
 
-                <div className="flex flex-row items-center gap-4 w-full lg:w-fit lg:gap-6 lg:justify-between">
-                    <div className="relative w-full lg:w-fit">
+            <Card className="gap-0">
+                <CardHeader className="border-b flex flex-col sm:flex-row items-stretch sm:items-center gap-3 sm:justify-between">
+                    <div className="relative w-full sm:w-fit sm:flex-1 sm:max-w-sm">
                         <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
                         <Input
                             placeholder={t("clients.search.placeholder")}
@@ -103,68 +92,6 @@ export default function Clients() {
                         <Plus className="h-4 w-4 mr-0 md:mr-2" />
                         <span className="hidden md:inline-flex">{t("clients.actions.addNew")}</span>
                     </Button>
-                </div>
-            </div>
-
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-                <Card>
-                    <CardContent>
-                        <div className="flex items-center space-x-4">
-                            <div className="p-3 bg-blue-100 rounded-lg">
-                                <Users className="h-6 w-6 text-blue-600" />
-                            </div>
-                            <div>
-                                <p className="text-2xl font-semibold text-foreground">{clients?.clients.length || 0}</p>
-                                <p className="text-sm text-primary">{t("clients.stats.total")}</p>
-                            </div>
-                        </div>
-                    </CardContent>
-                </Card>
-
-                <Card>
-                    <CardContent>
-                        <div className="flex items-center space-x-4">
-                            <div className="p-3 bg-green-100 rounded-lg">
-                                <div className="w-6 h-6 flex items-center justify-center">
-                                    <div className="w-3 h-3 bg-green-500 rounded-full"></div>
-                                </div>
-                            </div>
-                            <div>
-                                <p className="text-2xl font-semibold text-foreground">
-                                    {clients?.clients.filter((c) => c.isActive).length || 0}
-                                </p>
-                                <p className="text-sm text-primary">{t("clients.stats.active")}</p>
-                            </div>
-                        </div>
-                    </CardContent>
-                </Card>
-
-                <Card>
-                    <CardContent>
-                        <div className="flex items-center space-x-4">
-                            <div className="p-3 bg-gray-100 rounded-lg">
-                                <div className="w-6 h-6 flex items-center justify-center">
-                                    <div className="w-3 h-3 bg-gray-400 rounded-full"></div>
-                                </div>
-                            </div>
-                            <div>
-                                <p className="text-2xl font-semibold text-foreground">
-                                    {clients?.clients.filter((c) => !c.isActive).length || 0}
-                                </p>
-                                <p className="text-sm text-primary">{t("clients.stats.inactive")}</p>
-                            </div>
-                        </div>
-                    </CardContent>
-                </Card>
-            </div>
-
-            <Card className="gap-0">
-                <CardHeader className="border-b">
-                    <CardTitle className="flex items-center space-x-2">
-                        <Users className="h-5 w-5 " />
-                        <span>{t("clients.list.title")}</span>
-                    </CardTitle>
-                    <CardDescription>{t("clients.list.description")}</CardDescription>
                 </CardHeader>
 
                 <CardContent className="p-0">

--- a/frontend/src/pages/(app)/dashboard.tsx
+++ b/frontend/src/pages/(app)/dashboard.tsx
@@ -20,6 +20,7 @@ import { InvoiceList } from "@/pages/(app)/invoices/_components/invoice-list"
 import { QuoteList } from "@/pages/(app)/quotes/_components/quote-list"
 import type React from "react"
 import { authClient } from "@/lib/auth"
+import { usePageHeader } from "@/hooks/use-page-header"
 import { useSse } from "@/hooks/use-fetch"
 import { useTranslation } from "react-i18next"
 
@@ -65,6 +66,8 @@ export default function Dashboard() {
 
     const { data: dashboardData } = useSse<DashboardData>("/api/dashboard/sse")
 
+    usePageHeader(t("dashboard.title"), <LayoutDashboard className="h-5 w-5 text-blue-600" />)
+
     const formatCurrency = (amount: number | null | undefined) => {
         return new Intl.NumberFormat("en-US", {
             style: "currency",
@@ -86,16 +89,8 @@ export default function Dashboard() {
 
     return (
         <div className="max-w-7xl mx-auto space-y-6 p-6">
-            <div className="flex items-center space-x-3">
-                <div className="p-2 bg-blue-100 rounded-lg">
-                    <LayoutDashboard className="h-5 w-5 text-blue-600" />
-                </div>
-                <div>
-                    <h1 className="text-2xl font-bold text-foreground">{t("dashboard.title")}</h1>
-                    {/* @ts-ignore */}
-                    <p className="text-muted-foreground">{t("dashboard.welcomeMessage", { firstname: user?.user.firstname })}</p>
-                </div>
-            </div>
+            {/* @ts-ignore */}
+            <p className="text-muted-foreground">{t("dashboard.welcomeMessage", { firstname: user?.user?.firstname })}</p>
 
             <section className="space-y-6">
                 <div className="flex items-center space-x-3">

--- a/frontend/src/pages/(app)/invoices/_components/client-select-field.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/client-select-field.tsx
@@ -1,0 +1,51 @@
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+
+import type { Client } from "@/types"
+import { Button } from "@/components/ui/button"
+import SearchSelect from "@/components/search-input"
+import { useFormContext } from "react-hook-form"
+import { useTranslation } from "react-i18next"
+
+interface ClientSelectFieldProps {
+    translationPrefix: "invoices" | "recurringInvoices"
+    dataCy: string
+    clients: Client[]
+    onSearchChange: (term: string) => void
+    onRequestCreateClient: () => void
+}
+
+export function ClientSelectField({ translationPrefix, dataCy, clients, onSearchChange, onRequestCreateClient }: ClientSelectFieldProps) {
+    const { t } = useTranslation()
+    const { control } = useFormContext()
+
+    return (
+        <FormField
+            control={control}
+            name="clientId"
+            render={({ field }) => (
+                <FormItem>
+                    <FormLabel required>{t(`${translationPrefix}.upsert.form.client.label`)}</FormLabel>
+                    <FormControl>
+                        <SearchSelect
+                            options={(clients || []).map((c) => ({ label: c.name || c.contactFirstname + " " + c.contactLastname, value: c.id }))}
+                            value={field.value ?? ""}
+                            onValueChange={(val) => field.onChange(val || null)}
+                            onSearchChange={onSearchChange}
+                            placeholder={t(`${translationPrefix}.upsert.form.client.placeholder`)}
+                            data-cy={dataCy}
+                            noResultsComponent={
+                                <Button
+                                    variant="link"
+                                    onClick={onRequestCreateClient}
+                                >
+                                    {t(`${translationPrefix}.upsert.form.client.noOptions`)}
+                                </Button>
+                            }
+                        />
+                    </FormControl>
+                    <FormMessage />
+                </FormItem>
+            )}
+        />
+    )
+}

--- a/frontend/src/pages/(app)/invoices/_components/invoice-line-items-editor.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-line-items-editor.tsx
@@ -1,0 +1,241 @@
+import { DndContext, MouseSensor, TouchSensor, closestCenter, useSensor, useSensors } from "@dnd-kit/core"
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { GripVertical, Plus, Trash2 } from "lucide-react"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { SortableContext, arrayMove, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable"
+import { useEffect } from "react"
+import { useFieldArray, useFormContext } from "react-hook-form"
+
+import { BetterInput } from "@/components/better-input"
+import { Button } from "@/components/ui/button"
+import { CSS } from "@dnd-kit/utilities"
+import { Input } from "@/components/ui/input"
+import type React from "react"
+import { useTranslation } from "react-i18next"
+
+type ItemType = "HOUR" | "DAY" | "DEPOSIT" | "SERVICE" | "PRODUCT"
+
+interface InvoiceLineItemsEditorProps {
+    translationPrefix: "invoices" | "recurringInvoices"
+    defaultItemType: ItemType
+}
+
+export function InvoiceLineItemsEditor({ translationPrefix, defaultItemType }: InvoiceLineItemsEditorProps) {
+    const { t } = useTranslation()
+    const { control, setValue } = useFormContext()
+    const { fields, append, move, remove } = useFieldArray({
+        control,
+        name: "items",
+    })
+
+    const sensors = useSensors(useSensor(MouseSensor), useSensor(TouchSensor))
+
+    const onDragEnd = (event: any) => {
+        const { active, over } = event
+        if (active.id !== over?.id) {
+            const oldIndex = fields.findIndex((f) => f.id === active.id)
+            const newIndex = fields.findIndex((f) => f.id === over.id)
+            move(oldIndex, newIndex)
+            const reordered = arrayMove(fields, oldIndex, newIndex)
+            reordered.forEach((_, index) => {
+                setValue(`items.${index}.order`, index)
+            })
+        }
+    }
+
+    useEffect(() => {
+        fields.forEach((_, i) => {
+            setValue(`items.${i}.order`, i)
+        })
+    }, [fields, setValue])
+
+    return (
+        <FormItem>
+            <FormLabel>{t(`${translationPrefix}.upsert.form.items.label`)}</FormLabel>
+            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+                <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy}>
+                    <div className="space-y-2">
+                        {fields.map((fieldItem, index) => (
+                            <SortableItem
+                                key={fieldItem.id}
+                                id={fieldItem.id}
+                                dragHandle={<GripVertical className="cursor-grab text-muted-foreground" />}
+                            >
+                                <div className="flex gap-2 items-center">
+                                    <FormField
+                                        control={control}
+                                        name={`items.${index}.description`}
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormControl>
+                                                    <Input
+                                                        {...field}
+                                                        placeholder={t(
+                                                            `${translationPrefix}.upsert.form.items.description.placeholder`,
+                                                        )}
+                                                    />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+
+                                    <FormField
+                                        control={control}
+                                        name={`items.${index}.type`}
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormControl>
+                                                    <Select value={field.value ?? 'SERVICE'} onValueChange={(val) => field.onChange(val as any)}>
+                                                        <SelectTrigger className="w-32" size="sm" aria-label={t(`${translationPrefix}.upsert.form.items.type.label`) as string}>
+                                                            <SelectValue />
+                                                        </SelectTrigger>
+                                                        <SelectContent>
+                                                            <SelectItem value="HOUR">{t(`${translationPrefix}.upsert.form.items.type.hour`)}</SelectItem>
+                                                            <SelectItem value="DAY">{t(`${translationPrefix}.upsert.form.items.type.day`)}</SelectItem>
+                                                            <SelectItem value="DEPOSIT">{t(`${translationPrefix}.upsert.form.items.type.deposit`)}</SelectItem>
+                                                            <SelectItem value="SERVICE">{t(`${translationPrefix}.upsert.form.items.type.service`)}</SelectItem>
+                                                            <SelectItem value="PRODUCT">{t(`${translationPrefix}.upsert.form.items.type.product`)}</SelectItem>
+                                                        </SelectContent>
+                                                    </Select>
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+
+                                    <FormField
+                                        control={control}
+                                        name={`items.${index}.quantity`}
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormControl>
+                                                    <BetterInput
+                                                        {...field}
+                                                        defaultValue={field.value || ""}
+                                                        postAdornment={t(`${translationPrefix}.upsert.form.items.quantity.unit`)}
+                                                        type="number"
+                                                        step="0.001"
+                                                        placeholder={t(
+                                                            `${translationPrefix}.upsert.form.items.quantity.placeholder`,
+                                                        )}
+                                                        onChange={(e) =>
+                                                            field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
+                                                        }
+                                                    />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+
+                                    <FormField
+                                        control={control}
+                                        name={`items.${index}.unitPrice`}
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormControl>
+                                                    <BetterInput
+                                                        {...field}
+                                                        defaultValue={field.value || ""}
+                                                        postAdornment="$"
+                                                        type="number"
+                                                        step="0.01"
+                                                        placeholder={t(
+                                                            `${translationPrefix}.upsert.form.items.unitPrice.placeholder`,
+                                                        )}
+                                                        onChange={(e) =>
+                                                            field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
+                                                        }
+                                                    />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+
+                                    <FormField
+                                        control={control}
+                                        name={`items.${index}.vatRate`}
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormControl>
+                                                    <BetterInput
+                                                        {...field}
+                                                        defaultValue={field.value || 0}
+                                                        postAdornment="%"
+                                                        type="number"
+                                                        step="0.01"
+                                                        placeholder={t(
+                                                            `${translationPrefix}.upsert.form.items.vatRate.placeholder`,
+                                                        )}
+                                                        onChange={(e) =>
+                                                            field.onChange(
+                                                                e.target.value === ""
+                                                                    ? undefined
+                                                                    : Number.parseFloat(e.target.value.replace(",", ".")),
+                                                            )
+                                                        }
+                                                    />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+
+                                    <Button variant={"outline"} onClick={() => remove(index)}>
+                                        <Trash2 className="h-4 w-4 text-red-700" />
+                                    </Button>
+                                </div>
+                            </SortableItem>
+                        ))}
+                    </div>
+                </SortableContext>
+            </DndContext>
+
+            <Button
+                type="button"
+                variant="outline"
+                onClick={() =>
+                    append({
+                        description: "",
+                        type: defaultItemType,
+                        quantity: Number.NaN,
+                        unitPrice: Number.NaN,
+                        vatRate: Number.NaN,
+                        order: fields.length,
+                    })
+                }
+            >
+                <Plus className="mr-2 h-4 w-4" />
+                {t(`${translationPrefix}.upsert.form.items.addItem`)}
+            </Button>
+        </FormItem>
+    )
+}
+
+function SortableItem({
+    id,
+    children,
+    dragHandle,
+}: {
+    id: string
+    children: React.ReactNode
+    dragHandle: React.ReactNode
+}) {
+    const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id })
+
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    }
+
+    return (
+        <div ref={setNodeRef} style={style} className="flex items-center gap-2">
+            {children}
+            <div {...attributes} {...listeners}>
+                {dragHandle}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
@@ -235,7 +235,7 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                                 </div>
                             )}
                             {showCreateButton && (
-                                <Button onClick={() => (onAddClick ? onAddClick() : setCreateInvoiceDialog(true))}>
+                                <Button onClick={() => (onAddClick ? onAddClick() : setCreateInvoiceDialog(true))} dataCy="invoice-add-button">
                                     <Plus className="h-4 w-4 mr-0 md:mr-2" />
                                     <span className="hidden md:inline-flex">{t("invoices.list.actions.addNew")}</span>
                                 </Button>
@@ -453,6 +453,7 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                                                         size="icon"
                                                         onClick={() => handleDelete(invoice)}
                                                         className="text-gray-600 hover:text-red-600"
+                                                        dataCy="invoice-delete-button"
                                                     >
                                                         <Trash2 className="h-4 w-4" />
                                                     </Button>

--- a/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
@@ -24,9 +24,9 @@ interface InvoiceListProps {
     description?: string
     searchTerm?: string
     onSearchChange?: (value: string) => void
-    statusFilter?: "all" | "sent" | "paid"
-    onStatusFilterChange?: (value: "all" | "sent" | "paid") => void
-    statusCounts?: { all: number; sent: number; paid: number }
+    statusFilter?: "sent" | "paid" | "unpaid"
+    onStatusFilterChange?: (value: "sent" | "paid" | "unpaid" | undefined) => void
+    statusCounts?: { sent: number; paid: number; unpaid: number }
     page?: number
     pageCount?: number
     setPage?: (page: number) => void
@@ -203,17 +203,7 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                             {onStatusFilterChange && (
                                 <div className="flex items-center gap-2">
                                     <Badge
-                                        onClick={() => onStatusFilterChange("all")}
-                                        variant="outline"
-                                        className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all ${statusFilter === "all"
-                                            ? "border-transparent bg-gray-800 text-white font-semibold shadow-sm scale-105"
-                                            : "text-gray-500 hover:bg-gray-100"
-                                            }`}
-                                    >
-                                        {t("invoices.statusFilters.all")} ({statusCounts?.all ?? 0})
-                                    </Badge>
-                                    <Badge
-                                        onClick={() => onStatusFilterChange("sent")}
+                                        onClick={() => onStatusFilterChange(statusFilter === "sent" ? undefined : "sent")}
                                         variant="outline"
                                         className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter === "sent"
                                             ? "bg-yellow-500 text-white font-semibold shadow-sm scale-105"
@@ -223,7 +213,17 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                                         {t("invoices.statusFilters.sent")} ({statusCounts?.sent ?? 0})
                                     </Badge>
                                     <Badge
-                                        onClick={() => onStatusFilterChange("paid")}
+                                        onClick={() => onStatusFilterChange(statusFilter === "unpaid" ? undefined : "unpaid")}
+                                        variant="outline"
+                                        className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter === "unpaid"
+                                            ? "bg-blue-600 text-white font-semibold shadow-sm scale-105"
+                                            : "bg-blue-50 text-blue-700/70 hover:bg-blue-100"
+                                            }`}
+                                    >
+                                        {t("invoices.statusFilters.unpaid")} ({statusCounts?.unpaid ?? 0})
+                                    </Badge>
+                                    <Badge
+                                        onClick={() => onStatusFilterChange(statusFilter === "paid" ? undefined : "paid")}
                                         variant="outline"
                                         className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter === "paid"
                                             ? "bg-green-600 text-white font-semibold shadow-sm scale-105"

--- a/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
@@ -1,12 +1,14 @@
-import { Banknote, Code, Download, Edit, Eye, FileText, Mail, Plus, ReceiptText, Trash2 } from "lucide-react"
+import { Banknote, Code, Download, Edit, Eye, FileText, Mail, Plus, ReceiptText, Search, Trash2 } from "lucide-react"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react"
 import { useGet, useGetRaw, usePost } from "@/hooks/use-fetch"
 
 import BetterPagination from "../../../../components/pagination"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import type { Invoice } from "@/types"
+import { Input } from "@/components/ui/input"
+import { InvoiceStatus, type Invoice } from "@/types"
 import { InvoiceDeleteDialog } from "./invoice-delete"
 import { InvoicePdfModal } from "./invoice-pdf-view"
 import { InvoiceUpsert } from "./invoice-upsert"
@@ -18,14 +20,20 @@ import { useTranslation } from "react-i18next"
 interface InvoiceListProps {
     invoices: Invoice[]
     loading: boolean
-    title: string
-    description: string
+    title?: string
+    description?: string
+    searchTerm?: string
+    onSearchChange?: (value: string) => void
+    statusFilter?: "all" | "sent" | "paid"
+    onStatusFilterChange?: (value: "all" | "sent" | "paid") => void
+    statusCounts?: { all: number; sent: number; paid: number }
     page?: number
     pageCount?: number
     setPage?: (page: number) => void
     mutate?: () => void
     emptyState: React.ReactNode
     showCreateButton?: boolean
+    onAddClick?: () => void
 }
 
 export interface InvoiceListHandle {
@@ -39,7 +47,7 @@ interface PluginPdfFormat {
 
 export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
     (
-        { invoices, loading, title, description, page, pageCount, setPage, mutate, emptyState, showCreateButton = false },
+        { invoices, loading, title, description, searchTerm, onSearchChange, statusFilter, onStatusFilterChange, statusCounts, page, pageCount, setPage, mutate, emptyState, showCreateButton = false, onAddClick },
         ref,
     ) => {
         const { t } = useTranslation()
@@ -142,6 +150,8 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                     return "bg-red-100 text-red-800"
                 case "PAID":
                     return "bg-green-100 text-green-800"
+                case "UPCOMING":
+                    return "bg-purple-100 text-purple-800"
                 default:
                     return "bg-gray-100 text-gray-800"
             }
@@ -169,20 +179,68 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
         return (
             <>
                 <Card className="gap-0">
-                    <CardHeader className="border-b flex flex-row items-center justify-between">
-                        <div>
-                            <CardTitle className="flex items-center space-x-2">
-                                <ReceiptText className="h-5 w-5 " />
-                                <span>{title}</span>
-                            </CardTitle>
-                            <CardDescription>{description}</CardDescription>
+                    <CardHeader className="border-b flex flex-col sm:flex-row items-stretch sm:items-center gap-3 sm:justify-between">
+                        {title ? (
+                            <div>
+                                <CardTitle className="flex items-center space-x-2">
+                                    <ReceiptText className="h-5 w-5 " />
+                                    <span>{title}</span>
+                                </CardTitle>
+                                {description && <CardDescription>{description}</CardDescription>}
+                            </div>
+                        ) : onSearchChange ? (
+                            <div className="relative w-full sm:w-fit sm:flex-1 sm:max-w-sm">
+                                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+                                <Input
+                                    placeholder={t("invoices.search.placeholder")}
+                                    value={searchTerm}
+                                    onChange={(e) => onSearchChange(e.target.value)}
+                                    className="pl-10 w-full"
+                                />
+                            </div>
+                        ) : null}
+                        <div className="flex items-center gap-2 sm:ml-auto">
+                            {onStatusFilterChange && (
+                                <div className="flex items-center gap-2">
+                                    <Badge
+                                        onClick={() => onStatusFilterChange("all")}
+                                        variant="outline"
+                                        className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all ${statusFilter === "all"
+                                            ? "border-transparent bg-gray-800 text-white font-semibold shadow-sm scale-105"
+                                            : "text-gray-500 hover:bg-gray-100"
+                                            }`}
+                                    >
+                                        {t("invoices.statusFilters.all")} ({statusCounts?.all ?? 0})
+                                    </Badge>
+                                    <Badge
+                                        onClick={() => onStatusFilterChange("sent")}
+                                        variant="outline"
+                                        className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter === "sent"
+                                            ? "bg-yellow-500 text-white font-semibold shadow-sm scale-105"
+                                            : "bg-yellow-50 text-yellow-700/70 hover:bg-yellow-100"
+                                            }`}
+                                    >
+                                        {t("invoices.statusFilters.sent")} ({statusCounts?.sent ?? 0})
+                                    </Badge>
+                                    <Badge
+                                        onClick={() => onStatusFilterChange("paid")}
+                                        variant="outline"
+                                        className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter === "paid"
+                                            ? "bg-green-600 text-white font-semibold shadow-sm scale-105"
+                                            : "bg-green-50 text-green-700/70 hover:bg-green-100"
+                                            }`}
+                                    >
+                                        {t("invoices.statusFilters.paid")} ({statusCounts?.paid ?? 0})
+                                    </Badge>
+                                </div>
+                            )}
+                            {showCreateButton && (
+                                <Button onClick={() => (onAddClick ? onAddClick() : setCreateInvoiceDialog(true))}>
+                                    <Plus className="h-4 w-4 mr-0 md:mr-2" />
+                                    <span className="hidden md:inline-flex">{t("invoices.list.actions.addNew")}</span>
+                                </Button>
+                            )}
                         </div>
-                        {showCreateButton && (
-                            <Button onClick={() => setCreateInvoiceDialog(true)}>
-                                <Plus className="h-4 w-4 mr-0 md:mr-2" />
-                                <span className="hidden md:inline-flex">{t("invoices.list.actions.addNew")}</span>
-                            </Button>
-                        )}
                     </CardHeader>
 
                     <CardContent className="p-0">
@@ -204,10 +262,14 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                                                 <div className="flex-1">
                                                     <div className="flex flex-wrap items-center gap-2">
                                                         <h3 className="font-medium text-foreground break-words">
-                                                            {t("invoices.list.item.title", {
-                                                                number: invoice.rawNumber || invoice.number,
-                                                                title: invoice.title,
-                                                            })}
+                                                            {invoice.status === InvoiceStatus.UPCOMING
+                                                                ? t("invoices.list.item.upcomingTitle", {
+                                                                    client: invoice.client.name || `${invoice.client.contactFirstname} ${invoice.client.contactLastname}`,
+                                                                })
+                                                                : t("invoices.list.item.title", {
+                                                                    number: invoice.rawNumber || invoice.number,
+                                                                    title: invoice.title,
+                                                                })}
                                                         </h3>
                                                         <span
                                                             data-cy="invoice-status"
@@ -222,14 +284,23 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                                                                 <span className="font-medium text-foreground">{t("invoices.list.item.client")}:</span>{" "}
                                                                 {invoice.client.name || invoice.client.contactFirstname + " " + invoice.client.contactLastname}
                                                             </span>
-                                                            <span>
-                                                                <span className="font-medium text-foreground">{t("invoices.list.item.issued")}:</span>{" "}
-                                                                {new Date(invoice.createdAt).toLocaleDateString()}
-                                                            </span>
-                                                            <span>
-                                                                <span className="font-medium text-foreground">{t("invoices.list.item.due")}:</span>{" "}
-                                                                {new Date(invoice.dueDate).toLocaleDateString()}
-                                                            </span>
+                                                            {invoice.status === InvoiceStatus.UPCOMING ? (
+                                                                <span>
+                                                                    <span className="font-medium text-foreground">{t("invoices.list.item.nextInvoiceDate")}:</span>{" "}
+                                                                    {new Date(invoice.dueDate).toLocaleDateString()}
+                                                                </span>
+                                                            ) : (
+                                                                <>
+                                                                    <span>
+                                                                        <span className="font-medium text-foreground">{t("invoices.list.item.issued")}:</span>{" "}
+                                                                        {new Date(invoice.createdAt).toLocaleDateString()}
+                                                                    </span>
+                                                                    <span>
+                                                                        <span className="font-medium text-foreground">{t("invoices.list.item.due")}:</span>{" "}
+                                                                        {new Date(invoice.dueDate).toLocaleDateString()}
+                                                                    </span>
+                                                                </>
+                                                            )}
                                                             {invoice.paymentMethod && (
                                                                 <span>
                                                                     <span className="font-medium text-foreground">
@@ -257,6 +328,7 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                                                 </div>
                                             </div>
 
+                                            {invoice.status !== InvoiceStatus.UPCOMING && (
                                             <div className="grid grid-cols-2 lg:flex justify-start sm:justify-end gap-1 md:gap-2">
                                                 <Button
                                                     tooltip={t("invoices.list.tooltips.view")}
@@ -396,6 +468,7 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                                                     <Plus className="h-4 w-4" />
                                                 </Button>
                                             </div>
+                                            )}
                                         </div>
                                     </div>
                                 ))}

--- a/frontend/src/pages/(app)/invoices/_components/invoice-upsert.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-upsert.tsx
@@ -1,24 +1,20 @@
 import type { Client, Invoice, PaymentMethod, Quote } from "@/types"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { DndContext, MouseSensor, TouchSensor, closestCenter, useSensor, useSensors } from "@dnd-kit/core"
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
-import { GripVertical, Plus, Trash2 } from "lucide-react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { SortableContext, arrayMove, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useEffect, useState } from "react"
-import { useFieldArray, useForm } from "react-hook-form"
+import { useForm } from "react-hook-form"
 import { useGet, usePatch, usePost } from "@/hooks/use-fetch"
 
 import { BetterInput } from "@/components/better-input"
 import { Button } from "@/components/ui/button"
-import { CSS } from "@dnd-kit/utilities"
+import { ClientSelectField } from "./client-select-field"
 import { ClientUpsert } from "../../clients/_components/client-upsert"
 import CurrencySelect from "@/components/currency-select"
 import { DatePicker } from "@/components/date-picker"
-import { Input } from "@/components/ui/input"
+import { InvoiceLineItemsEditor } from "./invoice-line-items-editor"
 import { PaymentMethodType } from "@/types"
-import type React from "react"
 import SearchSelect from "@/components/search-input"
 import { Separator } from "@/components/ui/separator"
 import { Switch } from "@/components/ui/switch"
@@ -34,6 +30,41 @@ interface InvoiceUpsertDialogProps {
 }
 
 type CreationMode = "invoice" | "recurring"
+
+function createItemSchema(t: (key: string) => string, translationPrefix: "invoices" | "recurringInvoices", typeSchema: z.ZodTypeAny) {
+    return z.object({
+        id: z.string().optional(),
+        description: z
+            .string()
+            .min(1, t(`${translationPrefix}.upsert.form.items.description.errors.required`))
+            .refine((val) => val !== "", {
+                message: t(`${translationPrefix}.upsert.form.items.description.errors.required`),
+            }),
+        type: typeSchema,
+        quantity: z
+            .number({
+                invalid_type_error: t(`${translationPrefix}.upsert.form.items.quantity.errors.required`),
+            })
+            .min(0.001, t(`${translationPrefix}.upsert.form.items.quantity.errors.min`))
+            .refine((val) => !isNaN(val), {
+                message: t(`${translationPrefix}.upsert.form.items.quantity.errors.invalid`),
+            }),
+        unitPrice: z
+            .number({
+                invalid_type_error: t(`${translationPrefix}.upsert.form.items.unitPrice.errors.required`),
+            })
+            .min(0, t(`${translationPrefix}.upsert.form.items.unitPrice.errors.min`))
+            .refine((val) => !isNaN(val), {
+                message: t(`${translationPrefix}.upsert.form.items.unitPrice.errors.invalid`),
+            }),
+        vatRate: z
+            .number({
+                invalid_type_error: t(`${translationPrefix}.upsert.form.items.vatRate.errors.required`),
+            })
+            .min(0, t(`${translationPrefix}.upsert.form.items.vatRate.errors.min`)),
+        order: z.number(),
+    })
+}
 
 export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDialogProps) {
     const { t } = useTranslation()
@@ -66,38 +97,7 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
             .min(0, t("invoices.upsert.form.discountRate.errors.min"))
             .max(100, t("invoices.upsert.form.discountRate.errors.max")),
         items: z.array(
-            z.object({
-                id: z.string().optional(),
-                description: z
-                    .string()
-                    .min(1, t("invoices.upsert.form.items.description.errors.required"))
-                    .refine((val) => val !== "", {
-                        message: t("invoices.upsert.form.items.description.errors.required"),
-                    }),
-                quantity: z
-                    .number({
-                        invalid_type_error: t("invoices.upsert.form.items.quantity.errors.required"),
-                    })
-                    .min(0.001, t("invoices.upsert.form.items.quantity.errors.min"))
-                    .refine((val) => !isNaN(val), {
-                        message: t("invoices.upsert.form.items.quantity.errors.invalid"),
-                    }),
-                unitPrice: z
-                    .number({
-                        invalid_type_error: t("invoices.upsert.form.items.unitPrice.errors.required"),
-                    })
-                    .min(0, t("invoices.upsert.form.items.unitPrice.errors.min"))
-                    .refine((val) => !isNaN(val), {
-                        message: t("invoices.upsert.form.items.unitPrice.errors.invalid"),
-                    }),
-                vatRate: z
-                    .number({
-                        invalid_type_error: t("invoices.upsert.form.items.vatRate.errors.required"),
-                    })
-                    .min(0, t("invoices.upsert.form.items.vatRate.errors.min")),
-                type: z.enum(['HOUR', 'DAY', 'DEPOSIT', 'SERVICE', 'PRODUCT']).optional(),
-                order: z.number(),
-            }),
+            createItemSchema(t, "invoices", z.enum(['HOUR', 'DAY', 'DEPOSIT', 'SERVICE', 'PRODUCT']).optional()),
         ),
     })
 
@@ -121,38 +121,7 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
         currency: z.string().optional(),
         autoSend: z.boolean().optional(),
         items: z.array(
-            z.object({
-                id: z.string().optional(),
-                description: z
-                    .string()
-                    .min(1, t("recurringInvoices.upsert.form.items.description.errors.required"))
-                    .refine((val) => val !== "", {
-                        message: t("recurringInvoices.upsert.form.items.description.errors.required"),
-                    }),
-                type: z.string(),
-                quantity: z
-                    .number({
-                        invalid_type_error: t("recurringInvoices.upsert.form.items.quantity.errors.required"),
-                    })
-                    .min(0.001, t("recurringInvoices.upsert.form.items.quantity.errors.min"))
-                    .refine((val) => !isNaN(val), {
-                        message: t("recurringInvoices.upsert.form.items.quantity.errors.invalid"),
-                    }),
-                unitPrice: z
-                    .number({
-                        invalid_type_error: t("recurringInvoices.upsert.form.items.unitPrice.errors.required"),
-                    })
-                    .min(0, t("recurringInvoices.upsert.form.items.unitPrice.errors.min"))
-                    .refine((val) => !isNaN(val), {
-                        message: t("recurringInvoices.upsert.form.items.unitPrice.errors.invalid"),
-                    }),
-                vatRate: z
-                    .number({
-                        invalid_type_error: t("recurringInvoices.upsert.form.items.vatRate.errors.required"),
-                    })
-                    .min(0, t("recurringInvoices.upsert.form.items.vatRate.errors.min")),
-                order: z.number(),
-            }),
+            createItemSchema(t, "recurringInvoices", z.string()),
         ),
     })
 
@@ -238,65 +207,8 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
         }
     }, [invoice, form, recurringForm, isEdit])
 
-    const { control, handleSubmit, setValue } = form
-    const { fields, append, move, remove } = useFieldArray({
-        control,
-        name: "items",
-    })
-
-    const { control: recurringControl, handleSubmit: handleRecurringSubmit, setValue: setRecurringValue } = recurringForm
-    const { fields: recurringFields, append: appendRecurring, move: moveRecurring, remove: removeRecurring } = useFieldArray({
-        control: recurringControl,
-        name: "items",
-    })
-
-    const sensors = useSensors(useSensor(MouseSensor), useSensor(TouchSensor))
-
-    const onDragEnd = (event: any) => {
-        const { active, over } = event
-        if (active.id !== over?.id) {
-            const oldIndex = fields.findIndex((f) => f.id === active.id)
-            const newIndex = fields.findIndex((f) => f.id === over.id)
-            move(oldIndex, newIndex)
-            const reordered = arrayMove(fields, oldIndex, newIndex)
-            reordered.forEach((_, index) => {
-                setValue(`items.${index}.order`, index)
-            })
-        }
-    }
-
-    const onRecurringDragEnd = (event: any) => {
-        const { active, over } = event
-        if (active.id !== over?.id) {
-            const oldIndex = recurringFields.findIndex((f) => f.id === active.id)
-            const newIndex = recurringFields.findIndex((f) => f.id === over.id)
-            moveRecurring(oldIndex, newIndex)
-            const reordered = arrayMove(recurringFields, oldIndex, newIndex)
-            reordered.forEach((_, index) => {
-                setRecurringValue(`items.${index}.order`, index)
-            })
-        }
-    }
-
-    useEffect(() => {
-        fields.forEach((_, i) => {
-            setValue(`items.${i}.order`, i)
-        })
-    }, [fields, setValue])
-
-    useEffect(() => {
-        recurringFields.forEach((_, i) => {
-            setRecurringValue(`items.${i}.order`, i)
-        })
-    }, [recurringFields, setRecurringValue])
-
-    const onRemove = (index: number) => {
-        remove(index)
-    }
-
-    const onRemoveRecurring = (index: number) => {
-        removeRecurring(index)
-    }
+    const { control, handleSubmit } = form
+    const { control: recurringControl, handleSubmit: handleRecurringSubmit } = recurringForm
 
     const onSubmit = (data: z.infer<typeof invoiceSchema>) => {
         const trigger = isEdit ? updateTrigger : createTrigger
@@ -357,7 +269,7 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
 
                     <div className="flex-1 overflow-y-auto px-6 py-4">
                         {mode === "invoice" ? (
-                            <Form {...form}>
+                            <Form {...form} key="invoice-form-mode">
                                 <form id="invoice-form" onSubmit={handleSubmit(onSubmit)} className="space-y-4" data-cy="invoice-form">
                                     <FormField
                                         control={control}
@@ -401,33 +313,12 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
                                         )}
                                     />
 
-                                    <FormField
-                                        control={control}
-                                        name="clientId"
-                                        render={({ field }) => (
-                                            <FormItem>
-                                                <FormLabel required>{t("invoices.upsert.form.client.label")}</FormLabel>
-                                                <FormControl>
-                                                    <SearchSelect
-                                                        options={(clients || []).map((c) => ({ label: c.name || c.contactFirstname + " " + c.contactLastname, value: c.id }))}
-                                                        value={field.value ?? ""}
-                                                        onValueChange={(val) => field.onChange(val || null)}
-                                                        onSearchChange={setClientsSearchTerm}
-                                                        placeholder={t("invoices.upsert.form.client.placeholder")}
-                                                        data-cy="invoice-client-select"
-                                                        noResultsComponent={
-                                                            <Button
-                                                                variant="link"
-                                                                onClick={() => setClientDialogOpen(true)}
-                                                            >
-                                                                {t("invoices.upsert.form.client.noOptions")}
-                                                            </Button>
-                                                        }
-                                                    />
-                                                </FormControl>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )}
+                                    <ClientSelectField
+                                        translationPrefix="invoices"
+                                        dataCy="invoice-client-select"
+                                        clients={clients || []}
+                                        onSearchChange={setClientsSearchTerm}
+                                        onRequestCreateClient={() => setClientDialogOpen(true)}
                                     />
 
                                     <FormField
@@ -540,171 +431,11 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
                                     />
 
 
-                                    <FormItem>
-                                        <FormLabel>{t("invoices.upsert.form.items.label")}</FormLabel>
-                                        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
-                                            <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy}>
-                                                <div className="space-y-2">
-                                                    {fields.map((fieldItem, index) => (
-                                                        <SortableItem
-                                                            key={fieldItem.id}
-                                                            id={fieldItem.id}
-                                                            dragHandle={<GripVertical className="cursor-grab text-muted-foreground" />}
-                                                        >
-                                                            <div className="flex gap-2 items-center">
-                                                                <FormField
-                                                                    control={control}
-                                                                    name={`items.${index}.description`}
-                                                                    render={({ field }) => (
-                                                                        <FormItem>
-                                                                            <FormControl>
-                                                                                <Input
-                                                                                    {...field}
-                                                                                    placeholder={t(
-                                                                                        `invoices.upsert.form.items.description.placeholder`,
-                                                                                    )}
-                                                                                />
-                                                                            </FormControl>
-                                                                            <FormMessage />
-                                                                        </FormItem>
-                                                                    )}
-                                                                />
-
-                                                                <FormField
-                                                                    control={control}
-                                                                    name={`items.${index}.type`}
-                                                                    render={({ field }) => (
-                                                                        <FormItem>
-                                                                            <FormControl>
-                                                                                <Select value={field.value ?? 'SERVICE'} onValueChange={(val) => field.onChange(val as any)}>
-                                                                                    <SelectTrigger className="w-32 mb-0" aria-label={t("invoices.upsert.form.items.type.label") as string}>
-                                                                                        <SelectValue />
-                                                                                    </SelectTrigger>
-                                                                                    <SelectContent>
-                                                                                        <SelectItem value="HOUR">{t("invoices.upsert.form.items.type.hour")}</SelectItem>
-                                                                                        <SelectItem value="DAY">{t("invoices.upsert.form.items.type.day")}</SelectItem>
-                                                                                        <SelectItem value="DEPOSIT">{t("invoices.upsert.form.items.type.deposit")}</SelectItem>
-                                                                                        <SelectItem value="SERVICE">{t("invoices.upsert.form.items.type.service")}</SelectItem>
-                                                                                        <SelectItem value="PRODUCT">{t("invoices.upsert.form.items.type.product")}</SelectItem>
-                                                                                    </SelectContent>
-                                                                                </Select>
-                                                                            </FormControl>
-                                                                            <FormMessage />
-                                                                        </FormItem>
-                                                                    )}
-                                                                />
-
-                                                                <FormField
-                                                                    control={control}
-                                                                    name={`items.${index}.quantity`}
-                                                                    render={({ field }) => (
-                                                                        <FormItem>
-                                                                            <FormControl>
-                                                                                <BetterInput
-                                                                                    {...field}
-                                                                                    defaultValue={field.value || ""}
-                                                                                    postAdornment={t(`invoices.upsert.form.items.quantity.unit`)}
-                                                                                    type="number"
-                                                                                    step="0.001"
-                                                                                    placeholder={t(
-                                                                                        `invoices.upsert.form.items.quantity.placeholder`,
-                                                                                    )}
-                                                                                    onChange={(e) =>
-                                                                                        field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                                                                                    }
-                                                                                />
-                                                                            </FormControl>
-                                                                            <FormMessage />
-                                                                        </FormItem>
-                                                                    )}
-                                                                />
-
-                                                                <FormField
-                                                                    control={control}
-                                                                    name={`items.${index}.unitPrice`}
-                                                                    render={({ field }) => (
-                                                                        <FormItem>
-                                                                            <FormControl>
-                                                                                <BetterInput
-                                                                                    {...field}
-                                                                                    defaultValue={field.value || ""}
-                                                                                    postAdornment="$"
-                                                                                    type="number"
-                                                                                    step="0.01"
-                                                                                    placeholder={t(
-                                                                                        `invoices.upsert.form.items.unitPrice.placeholder`,
-                                                                                    )}
-                                                                                    onChange={(e) =>
-                                                                                        field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                                                                                    }
-                                                                                />
-                                                                            </FormControl>
-                                                                            <FormMessage />
-                                                                        </FormItem>
-                                                                    )}
-                                                                />
-
-                                                                <FormField
-                                                                    control={control}
-                                                                    name={`items.${index}.vatRate`}
-                                                                    render={({ field }) => (
-                                                                        <FormItem>
-                                                                            <FormControl>
-                                                                                <BetterInput
-                                                                                    {...field}
-                                                                                    defaultValue={field.value || 0}
-                                                                                    postAdornment="%"
-                                                                                    type="number"
-                                                                                    step="0.01"
-                                                                                    placeholder={t(
-                                                                                        `invoices.upsert.form.items.vatRate.placeholder`,
-                                                                                    )}
-                                                                                    onChange={(e) =>
-                                                                                        field.onChange(
-                                                                                            e.target.value === ""
-                                                                                                ? undefined
-                                                                                                : Number.parseFloat(e.target.value.replace(",", ".")),
-                                                                                        )
-                                                                                    }
-                                                                                />
-                                                                            </FormControl>
-                                                                            <FormMessage />
-                                                                        </FormItem>
-                                                                    )}
-                                                                />
-
-                                                                <Button variant={"outline"} onClick={() => onRemove(index)}>
-                                                                    <Trash2 className="h-4 w-4 text-red-700" />
-                                                                </Button>
-                                                            </div>
-                                                        </SortableItem>
-                                                    ))}
-                                                </div>
-                                            </SortableContext>
-                                        </DndContext>
-
-                                        <Button
-                                            type="button"
-                                            variant="outline"
-                                            onClick={() =>
-                                                append({
-                                                    description: "",
-                                                    quantity: Number.NaN,
-                                                    unitPrice: Number.NaN,
-                                                    vatRate: Number.NaN,
-                                                    type: 'SERVICE',
-                                                    order: fields.length,
-                                                })
-                                            }
-                                        >
-                                            <Plus className="mr-2 h-4 w-4" />
-                                            {t("invoices.upsert.form.items.addItem")}
-                                        </Button>
-                                    </FormItem>
+                                    <InvoiceLineItemsEditor translationPrefix="invoices" defaultItemType="SERVICE" />
                                 </form>
                             </Form>
                         ) : (
-                            <Form {...recurringForm}>
+                            <Form {...recurringForm} key="recurring-form-mode">
                                 <form id="recurring-invoice-form" onSubmit={handleRecurringSubmit(onSubmitRecurring)} className="space-y-4" data-cy="recurring-invoice-form">
                                     <FormField
                                         control={recurringControl}
@@ -747,33 +478,12 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
                                         )}
                                     />
 
-                                    <FormField
-                                        control={recurringControl}
-                                        name="clientId"
-                                        render={({ field }) => (
-                                            <FormItem>
-                                                <FormLabel required>{t("recurringInvoices.upsert.form.client.label")}</FormLabel>
-                                                <FormControl>
-                                                    <SearchSelect
-                                                        options={(clients || []).map((c) => ({ label: c.name || c.contactFirstname + " " + c.contactLastname, value: c.id }))}
-                                                        value={field.value ?? ""}
-                                                        onValueChange={(val) => field.onChange(val || null)}
-                                                        onSearchChange={setClientsSearchTerm}
-                                                        placeholder={t("recurringInvoices.upsert.form.client.placeholder")}
-                                                        data-cy="recurring-invoice-client-select"
-                                                        noResultsComponent={
-                                                            <Button
-                                                                variant="link"
-                                                                onClick={() => setClientDialogOpen(true)}
-                                                            >
-                                                                {t("recurringInvoices.upsert.form.client.noOptions")}
-                                                            </Button>
-                                                        }
-                                                    />
-                                                </FormControl>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )}
+                                    <ClientSelectField
+                                        translationPrefix="recurringInvoices"
+                                        dataCy="recurring-invoice-client-select"
+                                        clients={clients || []}
+                                        onSearchChange={setClientsSearchTerm}
+                                        onRequestCreateClient={() => setClientDialogOpen(true)}
                                     />
 
                                     <FormField
@@ -924,167 +634,7 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
 
                                     <Separator className="my-4" />
 
-                                    <FormItem>
-                                        <FormLabel>{t("recurringInvoices.upsert.form.items.label")}</FormLabel>
-                                        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onRecurringDragEnd}>
-                                            <SortableContext items={recurringFields.map((f) => f.id)} strategy={verticalListSortingStrategy}>
-                                                <div className="space-y-2">
-                                                    {recurringFields.map((fieldItem, index) => (
-                                                        <SortableItem
-                                                            key={fieldItem.id}
-                                                            id={fieldItem.id}
-                                                            dragHandle={<GripVertical className="cursor-grab text-muted-foreground" />}
-                                                        >
-                                                            <div className="flex gap-2 items-center">
-                                                                <FormField
-                                                                    control={recurringControl}
-                                                                    name={`items.${index}.description`}
-                                                                    render={({ field }) => (
-                                                                        <FormItem>
-                                                                            <FormControl>
-                                                                                <Input
-                                                                                    {...field}
-                                                                                    placeholder={t(
-                                                                                        "recurringInvoices.upsert.form.items.description.placeholder",
-                                                                                    )}
-                                                                                />
-                                                                            </FormControl>
-                                                                            <FormMessage />
-                                                                        </FormItem>
-                                                                    )}
-                                                                />
-
-                                                                <FormField
-                                                                    control={recurringControl}
-                                                                    name={`items.${index}.type`}
-                                                                    render={({ field }) => (
-                                                                        <FormItem>
-                                                                            <FormControl>
-                                                                                <Select value={field.value ?? 'SERVICE'} onValueChange={(val) => field.onChange(val as any)}>
-                                                                                    <SelectTrigger className="w-32" size="sm" aria-label={t("recurringInvoices.upsert.form.items.type.label") as string}>
-                                                                                        <SelectValue />
-                                                                                    </SelectTrigger>
-                                                                                    <SelectContent>
-                                                                                        <SelectItem value="HOUR">{t("recurringInvoices.upsert.form.items.type.hour")}</SelectItem>
-                                                                                        <SelectItem value="DAY">{t("recurringInvoices.upsert.form.items.type.day")}</SelectItem>
-                                                                                        <SelectItem value="DEPOSIT">{t("recurringInvoices.upsert.form.items.type.deposit")}</SelectItem>
-                                                                                        <SelectItem value="SERVICE">{t("recurringInvoices.upsert.form.items.type.service")}</SelectItem>
-                                                                                        <SelectItem value="PRODUCT">{t("recurringInvoices.upsert.form.items.type.product")}</SelectItem>
-                                                                                    </SelectContent>
-                                                                                </Select>
-                                                                            </FormControl>
-                                                                            <FormMessage />
-                                                                        </FormItem>
-                                                                    )}
-                                                                />
-
-                                                                <FormField
-                                                                    control={recurringControl}
-                                                                    name={`items.${index}.quantity`}
-                                                                    render={({ field }) => (
-                                                                        <FormItem>
-                                                                            <FormControl>
-                                                                                <BetterInput
-                                                                                    {...field}
-                                                                                    defaultValue={field.value || ""}
-                                                                                    postAdornment={t("recurringInvoices.upsert.form.items.quantity.unit")}
-                                                                                    type="number"
-                                                                                    step="0.001"
-                                                                                    placeholder={t(
-                                                                                        "recurringInvoices.upsert.form.items.quantity.placeholder",
-                                                                                    )}
-                                                                                    onChange={(e) =>
-                                                                                        field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                                                                                    }
-                                                                                />
-                                                                            </FormControl>
-                                                                            <FormMessage />
-                                                                        </FormItem>
-                                                                    )}
-                                                                />
-
-                                                                <FormField
-                                                                    control={recurringControl}
-                                                                    name={`items.${index}.unitPrice`}
-                                                                    render={({ field }) => (
-                                                                        <FormItem>
-                                                                            <FormControl>
-                                                                                <BetterInput
-                                                                                    {...field}
-                                                                                    defaultValue={field.value || ""}
-                                                                                    postAdornment="$"
-                                                                                    type="number"
-                                                                                    step="0.01"
-                                                                                    placeholder={t(
-                                                                                        "recurringInvoices.upsert.form.items.unitPrice.placeholder",
-                                                                                    )}
-                                                                                    onChange={(e) =>
-                                                                                        field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                                                                                    }
-                                                                                />
-                                                                            </FormControl>
-                                                                            <FormMessage />
-                                                                        </FormItem>
-                                                                    )}
-                                                                />
-
-                                                                <FormField
-                                                                    control={recurringControl}
-                                                                    name={`items.${index}.vatRate`}
-                                                                    render={({ field }) => (
-                                                                        <FormItem>
-                                                                            <FormControl>
-                                                                                <BetterInput
-                                                                                    {...field}
-                                                                                    defaultValue={field.value || 0}
-                                                                                    postAdornment="%"
-                                                                                    type="number"
-                                                                                    step="0.01"
-                                                                                    placeholder={t(
-                                                                                        "recurringInvoices.upsert.form.items.vatRate.placeholder",
-                                                                                    )}
-                                                                                    onChange={(e) =>
-                                                                                        field.onChange(
-                                                                                            e.target.value === ""
-                                                                                                ? undefined
-                                                                                                : Number.parseFloat(e.target.value.replace(",", ".")),
-                                                                                        )
-                                                                                    }
-                                                                                />
-                                                                            </FormControl>
-                                                                            <FormMessage />
-                                                                        </FormItem>
-                                                                    )}
-                                                                />
-
-                                                                <Button variant={"outline"} onClick={() => onRemoveRecurring(index)}>
-                                                                    <Trash2 className="h-4 w-4 text-red-700" />
-                                                                </Button>
-                                                            </div>
-                                                        </SortableItem>
-                                                    ))}
-                                                </div>
-                                            </SortableContext>
-                                        </DndContext>
-
-                                        <Button
-                                            type="button"
-                                            variant="outline"
-                                            onClick={() =>
-                                                appendRecurring({
-                                                    description: "",
-                                                    type: "HOUR",
-                                                    quantity: Number.NaN,
-                                                    unitPrice: Number.NaN,
-                                                    vatRate: Number.NaN,
-                                                    order: recurringFields.length,
-                                                })
-                                            }
-                                        >
-                                            <Plus className="mr-2 h-4 w-4" />
-                                            {t("recurringInvoices.upsert.form.items.addItem")}
-                                        </Button>
-                                    </FormItem>
+                                    <InvoiceLineItemsEditor translationPrefix="recurringInvoices" defaultItemType="HOUR" />
 
                                     <Separator className="my-4" />
 
@@ -1135,31 +685,5 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
                 onCreate={handleClientCreate}
             />
         </>
-    )
-}
-
-function SortableItem({
-    id,
-    children,
-    dragHandle,
-}: {
-    id: string
-    children: React.ReactNode
-    dragHandle: React.ReactNode
-}) {
-    const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id })
-
-    const style = {
-        transform: CSS.Transform.toString(transform),
-        transition,
-    }
-
-    return (
-        <div ref={setNodeRef} style={style} className="flex items-center gap-2">
-            {children}
-            <div {...attributes} {...listeners}>
-                {dragHandle}
-            </div>
-        </div>
     )
 }

--- a/frontend/src/pages/(app)/invoices/_components/invoice-upsert.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-upsert.tsx
@@ -5,6 +5,7 @@ import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, For
 import { GripVertical, Plus, Trash2 } from "lucide-react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { SortableContext, arrayMove, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useEffect, useState } from "react"
 import { useFieldArray, useForm } from "react-hook-form"
 import { useGet, usePatch, usePost } from "@/hooks/use-fetch"
@@ -19,6 +20,8 @@ import { Input } from "@/components/ui/input"
 import { PaymentMethodType } from "@/types"
 import type React from "react"
 import SearchSelect from "@/components/search-input"
+import { Separator } from "@/components/ui/separator"
+import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { useTranslation } from "react-i18next"
 import { z } from "zod"
@@ -30,9 +33,19 @@ interface InvoiceUpsertDialogProps {
     onOpenChange: (open: boolean) => void
 }
 
+type CreationMode = "invoice" | "recurring"
+
 export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDialogProps) {
     const { t } = useTranslation()
     const isEdit = !!invoice
+
+    const [mode, setMode] = useState<CreationMode>("invoice")
+
+    useEffect(() => {
+        if (open) {
+            setMode("invoice")
+        }
+    }, [open])
 
     const invoiceSchema = z.object({
         quoteId: z
@@ -88,6 +101,61 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
         ),
     })
 
+    const recurringInvoiceSchema = z.object({
+        quoteId: z.string().optional(),
+        clientId: z
+            .string()
+            .min(1, t("recurringInvoices.upsert.form.client.errors.required"))
+            .refine((val) => val !== "", {
+                message: t("recurringInvoices.upsert.form.client.errors.required"),
+            }),
+        notes: z.string().optional(),
+        paymentMethodId: z.string().optional(),
+        frequency: z.enum(["WEEKLY", "BIWEEKLY", "MONTHLY", "BIMONTHLY", "QUARTERLY", "QUADMONTHLY", "SEMIANNUALLY", "ANNUALLY"], {
+            errorMap: () => ({
+                message: t("recurringInvoices.upsert.form.frequency.errors.required"),
+            }),
+        }),
+        count: z.number().optional(),
+        until: z.date().optional(),
+        currency: z.string().optional(),
+        autoSend: z.boolean().optional(),
+        items: z.array(
+            z.object({
+                id: z.string().optional(),
+                description: z
+                    .string()
+                    .min(1, t("recurringInvoices.upsert.form.items.description.errors.required"))
+                    .refine((val) => val !== "", {
+                        message: t("recurringInvoices.upsert.form.items.description.errors.required"),
+                    }),
+                type: z.string(),
+                quantity: z
+                    .number({
+                        invalid_type_error: t("recurringInvoices.upsert.form.items.quantity.errors.required"),
+                    })
+                    .min(0.001, t("recurringInvoices.upsert.form.items.quantity.errors.min"))
+                    .refine((val) => !isNaN(val), {
+                        message: t("recurringInvoices.upsert.form.items.quantity.errors.invalid"),
+                    }),
+                unitPrice: z
+                    .number({
+                        invalid_type_error: t("recurringInvoices.upsert.form.items.unitPrice.errors.required"),
+                    })
+                    .min(0, t("recurringInvoices.upsert.form.items.unitPrice.errors.min"))
+                    .refine((val) => !isNaN(val), {
+                        message: t("recurringInvoices.upsert.form.items.unitPrice.errors.invalid"),
+                    }),
+                vatRate: z
+                    .number({
+                        invalid_type_error: t("recurringInvoices.upsert.form.items.vatRate.errors.required"),
+                    })
+                    .min(0, t("recurringInvoices.upsert.form.items.vatRate.errors.min")),
+                order: z.number(),
+            }),
+        ),
+    })
+
     const [clientSearchTerm, setClientsSearchTerm] = useState("")
     const [quoteSearchTerm, setQuoteSearchTerm] = useState("")
     const [clientDialogOpen, setClientDialogOpen] = useState(false)
@@ -97,6 +165,7 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
 
     const { trigger: createTrigger } = usePost("/api/invoices")
     const { trigger: updateTrigger } = usePatch(`/api/invoices/${invoice?.id}`)
+    const { trigger: createRecurringTrigger } = usePost("/api/recurring-invoices")
 
     const form = useForm<z.infer<typeof invoiceSchema>>({
         resolver: zodResolver(invoiceSchema),
@@ -109,6 +178,18 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
             discountRate: 0,
             items: [],
             notes: "",
+        },
+    })
+
+    const recurringForm = useForm<z.infer<typeof recurringInvoiceSchema>>({
+        resolver: zodResolver(recurringInvoiceSchema),
+        defaultValues: {
+            quoteId: undefined,
+            clientId: "",
+            items: [],
+            notes: "",
+            frequency: "MONTHLY",
+            autoSend: false,
         },
     })
 
@@ -146,12 +227,26 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
                 discountRate: 0,
                 items: [],
             })
+            recurringForm.reset({
+                quoteId: undefined,
+                clientId: "",
+                items: [],
+                notes: "",
+                frequency: "MONTHLY",
+                autoSend: false,
+            })
         }
-    }, [invoice, form, isEdit])
+    }, [invoice, form, recurringForm, isEdit])
 
     const { control, handleSubmit, setValue } = form
     const { fields, append, move, remove } = useFieldArray({
         control,
+        name: "items",
+    })
+
+    const { control: recurringControl, handleSubmit: handleRecurringSubmit, setValue: setRecurringValue } = recurringForm
+    const { fields: recurringFields, append: appendRecurring, move: moveRecurring, remove: removeRecurring } = useFieldArray({
+        control: recurringControl,
         name: "items",
     })
 
@@ -170,19 +265,40 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
         }
     }
 
+    const onRecurringDragEnd = (event: any) => {
+        const { active, over } = event
+        if (active.id !== over?.id) {
+            const oldIndex = recurringFields.findIndex((f) => f.id === active.id)
+            const newIndex = recurringFields.findIndex((f) => f.id === over.id)
+            moveRecurring(oldIndex, newIndex)
+            const reordered = arrayMove(recurringFields, oldIndex, newIndex)
+            reordered.forEach((_, index) => {
+                setRecurringValue(`items.${index}.order`, index)
+            })
+        }
+    }
+
     useEffect(() => {
         fields.forEach((_, i) => {
             setValue(`items.${i}.order`, i)
         })
     }, [fields, setValue])
 
+    useEffect(() => {
+        recurringFields.forEach((_, i) => {
+            setRecurringValue(`items.${i}.order`, i)
+        })
+    }, [recurringFields, setRecurringValue])
+
     const onRemove = (index: number) => {
         remove(index)
     }
 
-    const onSubmit = (data: z.infer<typeof invoiceSchema>) => {
-        console.debug("Submitting invoice data:", data)
+    const onRemoveRecurring = (index: number) => {
+        removeRecurring(index)
+    }
 
+    const onSubmit = (data: z.infer<typeof invoiceSchema>) => {
         const trigger = isEdit ? updateTrigger : createTrigger
 
         trigger(data)
@@ -193,375 +309,823 @@ export function InvoiceUpsert({ invoice, open, onOpenChange }: InvoiceUpsertDial
             .catch((err) => console.error(err))
     }
 
+    const onSubmitRecurring = (data: z.infer<typeof recurringInvoiceSchema>) => {
+        createRecurringTrigger(data)
+            .then(() => {
+                onOpenChange(false)
+                recurringForm.reset()
+            })
+            .catch((err) => console.error(err))
+    }
+
     const handleClientCreate = (newClient: Client) => {
         setClientsSearchTerm("")
-        form.setValue("clientId", newClient.id)
         clients?.push(newClient)
-        form.trigger("clientId")
+        if (mode === "invoice") {
+            form.setValue("clientId", newClient.id)
+            form.trigger("clientId")
+        } else {
+            recurringForm.setValue("clientId", newClient.id)
+            recurringForm.trigger("clientId")
+        }
     }
 
     return (
         <>
             <Dialog open={open} onOpenChange={onOpenChange}>
-                <DialogContent className="max-w-sm lg:max-w-4xl" dataCy="invoice-dialog">
-                    <DialogHeader>
-                        <DialogTitle>{t(`invoices.upsert.title.${isEdit ? "edit" : "create"}`)}</DialogTitle>
+                <DialogContent
+                    className="max-w-sm lg:max-w-4xl h-[85dvh] max-h-[85dvh] p-0 gap-0 flex flex-col overflow-hidden"
+                    dataCy="invoice-dialog"
+                >
+                    <DialogHeader className="shrink-0 border-b px-6 py-4 space-y-3">
+                        <DialogTitle>
+                            {t(`invoices.upsert.title.${isEdit ? "edit" : "create"}`)}
+                        </DialogTitle>
+                        {!isEdit && (
+                            <Tabs value={mode} onValueChange={(value) => setMode(value as CreationMode)}>
+                                <TabsList>
+                                    <TabsTrigger value="invoice" data-cy="invoice-tab-invoice">
+                                        {t("invoices.upsert.tabs.invoice")}
+                                    </TabsTrigger>
+                                    <TabsTrigger value="recurring" data-cy="invoice-tab-recurring">
+                                        {t("invoices.upsert.tabs.recurring")}
+                                    </TabsTrigger>
+                                </TabsList>
+                            </Tabs>
+                        )}
                     </DialogHeader>
-                    <Form {...form}>
-                        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" data-cy="invoice-form">
-                            <FormField
-                                control={control}
-                                name="quoteId"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormLabel>{t("invoices.upsert.form.quote.label")}</FormLabel>
-                                        <FormControl>
-                                            <SearchSelect
-                                                options={(quotes || []).map((c) => ({
-                                                    label: `${c.number}${c.title ? ` (${c.title})` : ""}`,
-                                                    value: c.id,
-                                                }))}
-                                                value={field.value ?? ""}
-                                                onValueChange={(val) => {
-                                                    field.onChange(val || null)
-                                                    if (val) {
-                                                        const selectedQuote = quotes?.find((q) => q.id === val)
-                                                        form.setValue("clientId", selectedQuote?.clientId || "")
-                                                        form.setValue("notes", selectedQuote?.notes || "")
-                                                        form.setValue("paymentMethodId", (selectedQuote as any)?.paymentMethodId || "")
-                                                        form.setValue("currency", selectedQuote?.currency || "")
-                                                        form.setValue("discountRate", selectedQuote?.discountRate ?? 0)
-                                                        form.setValue('items', (selectedQuote?.items || []).map((item: any, index) => ({
-                                                            id: item.id,
-                                                            description: item.description || "",
-                                                            quantity: item.quantity || 1,
-                                                            unitPrice: item.unitPrice || 0,
-                                                            vatRate: item.vatRate || 0,
-                                                            type: item.type || 'SERVICE',
-                                                            order: index,
-                                                        })))
-                                                    }
-                                                }}
-                                                onSearchChange={setQuoteSearchTerm}
-                                                placeholder={t("invoices.upsert.form.quote.placeholder")}
-                                            />
-                                        </FormControl>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
-                            />
 
-                            <FormField
-                                control={control}
-                                name="clientId"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormLabel required>{t("invoices.upsert.form.client.label")}</FormLabel>
-                                        <FormControl>
-                                            <SearchSelect
-                                                options={(clients || []).map((c) => ({ label: c.name || c.contactFirstname + " " + c.contactLastname, value: c.id }))}
-                                                value={field.value ?? ""}
-                                                onValueChange={(val) => field.onChange(val || null)}
-                                                onSearchChange={setClientsSearchTerm}
-                                                placeholder={t("invoices.upsert.form.client.placeholder")}
-                                                data-cy="invoice-client-select"
-                                                noResultsComponent={
-                                                    <Button
-                                                        variant="link"
-                                                        onClick={() => setClientDialogOpen(true)}
-                                                    >
-                                                        {t("invoices.upsert.form.client.noOptions")}
-                                                    </Button>
-                                                }
-                                            />
-                                        </FormControl>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
-                            />
+                    <div className="flex-1 overflow-y-auto px-6 py-4">
+                        {mode === "invoice" ? (
+                            <Form {...form}>
+                                <form id="invoice-form" onSubmit={handleSubmit(onSubmit)} className="space-y-4" data-cy="invoice-form">
+                                    <FormField
+                                        control={control}
+                                        name="quoteId"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel>{t("invoices.upsert.form.quote.label")}</FormLabel>
+                                                <FormControl>
+                                                    <SearchSelect
+                                                        options={(quotes || []).map((c) => ({
+                                                            label: `${c.number}${c.title ? ` (${c.title})` : ""}`,
+                                                            value: c.id,
+                                                        }))}
+                                                        value={field.value ?? ""}
+                                                        onValueChange={(val) => {
+                                                            field.onChange(val || null)
+                                                            if (val) {
+                                                                const selectedQuote = quotes?.find((q) => q.id === val)
+                                                                form.setValue("clientId", selectedQuote?.clientId || "")
+                                                                form.setValue("notes", selectedQuote?.notes || "")
+                                                                form.setValue("paymentMethodId", (selectedQuote as any)?.paymentMethodId || "")
+                                                                form.setValue("currency", selectedQuote?.currency || "")
+                                                                form.setValue("discountRate", selectedQuote?.discountRate ?? 0)
+                                                                form.setValue('items', (selectedQuote?.items || []).map((item: any, index) => ({
+                                                                    id: item.id,
+                                                                    description: item.description || "",
+                                                                    quantity: item.quantity || 1,
+                                                                    unitPrice: item.unitPrice || 0,
+                                                                    vatRate: item.vatRate || 0,
+                                                                    type: item.type || 'SERVICE',
+                                                                    order: index,
+                                                                })))
+                                                            }
+                                                        }}
+                                                        onSearchChange={setQuoteSearchTerm}
+                                                        placeholder={t("invoices.upsert.form.quote.placeholder")}
+                                                    />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
 
-                            <FormField
-                                control={form.control}
-                                name="currency"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormLabel>{t("invoices.upsert.form.currency.label")}</FormLabel>
-                                        <FormControl>
-                                            <CurrencySelect value={field.value} onChange={(value) => field.onChange(value)} data-cy="invoice-currency-select" />
-                                        </FormControl>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
-                            />
+                                    <FormField
+                                        control={control}
+                                        name="clientId"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel required>{t("invoices.upsert.form.client.label")}</FormLabel>
+                                                <FormControl>
+                                                    <SearchSelect
+                                                        options={(clients || []).map((c) => ({ label: c.name || c.contactFirstname + " " + c.contactLastname, value: c.id }))}
+                                                        value={field.value ?? ""}
+                                                        onValueChange={(val) => field.onChange(val || null)}
+                                                        onSearchChange={setClientsSearchTerm}
+                                                        placeholder={t("invoices.upsert.form.client.placeholder")}
+                                                        data-cy="invoice-client-select"
+                                                        noResultsComponent={
+                                                            <Button
+                                                                variant="link"
+                                                                onClick={() => setClientDialogOpen(true)}
+                                                            >
+                                                                {t("invoices.upsert.form.client.noOptions")}
+                                                            </Button>
+                                                        }
+                                                    />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
 
-                            <FormField
-                                control={control}
-                                name="discountRate"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormLabel>{t("invoices.upsert.form.discountRate.label")}</FormLabel>
-                                        <FormControl>
-                                            <BetterInput
-                                                {...field}
-                                                defaultValue={field.value ?? 0}
-                                                postAdornment="%"
-                                                type="number"
-                                                step="0.01"
-                                                placeholder={t("invoices.upsert.form.discountRate.placeholder")}
-                                                onChange={(e) =>
-                                                    field.onChange(
-                                                        e.target.value === ""
-                                                            ? 0
-                                                            : Number.parseFloat(e.target.value.replace(",", ".")),
-                                                    )
-                                                }
-                                            />
-                                        </FormControl>
-                                        <FormDescription>
-                                            {t("invoices.upsert.form.discountRate.description")}
-                                        </FormDescription>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
-                            />
+                                    <FormField
+                                        control={form.control}
+                                        name="currency"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel>{t("invoices.upsert.form.currency.label")}</FormLabel>
+                                                <FormControl>
+                                                    <CurrencySelect value={field.value} onChange={(value) => field.onChange(value)} data-cy="invoice-currency-select" />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
 
-                            <FormField
-                                control={control}
-                                name="dueDate"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormLabel>{t("invoices.upsert.form.dueDate.label")}</FormLabel>
-                                        <FormControl>
-                                            <DatePicker
-                                                className="w-full"
-                                                value={field.value || null}
-                                                onChange={field.onChange}
-                                                placeholder={t("invoices.upsert.form.dueDate.placeholder")}
-                                            />
-                                        </FormControl>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
-                            />
+                                    <FormField
+                                        control={control}
+                                        name="discountRate"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel>{t("invoices.upsert.form.discountRate.label")}</FormLabel>
+                                                <FormControl>
+                                                    <BetterInput
+                                                        {...field}
+                                                        defaultValue={field.value ?? 0}
+                                                        postAdornment="%"
+                                                        type="number"
+                                                        step="0.01"
+                                                        placeholder={t("invoices.upsert.form.discountRate.placeholder")}
+                                                        onChange={(e) =>
+                                                            field.onChange(
+                                                                e.target.value === ""
+                                                                    ? 0
+                                                                    : Number.parseFloat(e.target.value.replace(",", ".")),
+                                                            )
+                                                        }
+                                                    />
+                                                </FormControl>
+                                                <FormDescription>
+                                                    {t("invoices.upsert.form.discountRate.description")}
+                                                </FormDescription>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
 
-                            <FormField
-                                control={control}
-                                name="notes"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormLabel>{t("invoices.upsert.form.notes.label")}</FormLabel>
-                                        <FormControl>
-                                            <Textarea {...field} placeholder={t("invoices.upsert.form.notes.placeholder")} className="max-h-40" />
-                                        </FormControl>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
-                            />
+                                    <FormField
+                                        control={control}
+                                        name="dueDate"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel>{t("invoices.upsert.form.dueDate.label")}</FormLabel>
+                                                <FormControl>
+                                                    <DatePicker
+                                                        className="w-full"
+                                                        value={field.value || null}
+                                                        onChange={field.onChange}
+                                                        placeholder={t("invoices.upsert.form.dueDate.placeholder")}
+                                                    />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
 
-                            <FormField
-                                control={control}
-                                name="paymentMethodId"
-                                render={({ field }) => (
+                                    <FormField
+                                        control={control}
+                                        name="notes"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel>{t("invoices.upsert.form.notes.label")}</FormLabel>
+                                                <FormControl>
+                                                    <Textarea {...field} placeholder={t("invoices.upsert.form.notes.placeholder")} className="max-h-40" />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+
+                                    <FormField
+                                        control={control}
+                                        name="paymentMethodId"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel>{t("invoices.upsert.form.paymentMethod.label")}</FormLabel>
+                                                <FormControl>
+                                                    <Select value={field.value ?? ""} onValueChange={(val) => {
+                                                        const v = val || "";
+                                                        field.onChange(v);
+                                                    }}>
+                                                        <SelectTrigger className="w-full" aria-label={t("invoices.upsert.form.paymentMethod.label") as string}>
+                                                            <SelectValue placeholder={t("invoices.upsert.form.paymentMethod.placeholder")} />
+                                                        </SelectTrigger>
+                                                        <SelectContent>
+                                                            {(paymentMethods || []).map((pm: PaymentMethod) => (
+                                                                <SelectItem key={pm.id} value={pm.id}>
+                                                                    {pm.name} - {pm.type == PaymentMethodType.BANK_TRANSFER ? t("paymentMethods.fields.type.bank_transfer") : pm.type == PaymentMethodType.PAYPAL ? t("paymentMethods.fields.type.paypal") : pm.type == PaymentMethodType.CHECK ? t("paymentMethods.fields.type.check") : pm.type == PaymentMethodType.CASH ? t("paymentMethods.fields.type.cash") : pm.type == PaymentMethodType.OTHER ? t("paymentMethods.fields.type.other") : pm.type}
+                                                                </SelectItem>
+                                                            ))}
+                                                        </SelectContent>
+                                                    </Select>
+                                                </FormControl>
+                                                <FormDescription>
+                                                    {t("invoices.upsert.form.paymentMethod.description")}
+                                                </FormDescription>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+
+
                                     <FormItem>
-                                        <FormLabel>{t("invoices.upsert.form.paymentMethod.label")}</FormLabel>
-                                        <FormControl>
-                                            <Select value={field.value ?? ""} onValueChange={(val) => {
-                                                const v = val || "";
-                                                field.onChange(v);
-                                            }}>
-                                                <SelectTrigger className="w-full" aria-label={t("invoices.upsert.form.paymentMethod.label") as string}>
-                                                    <SelectValue placeholder={t("invoices.upsert.form.paymentMethod.placeholder")} />
-                                                </SelectTrigger>
-                                                <SelectContent>
-                                                    {(paymentMethods || []).map((pm: PaymentMethod) => (
-                                                        <SelectItem key={pm.id} value={pm.id}>
-                                                            {pm.name} - {pm.type == PaymentMethodType.BANK_TRANSFER ? t("paymentMethods.fields.type.bank_transfer") : pm.type == PaymentMethodType.PAYPAL ? t("paymentMethods.fields.type.paypal") : pm.type == PaymentMethodType.CHECK ? t("paymentMethods.fields.type.check") : pm.type == PaymentMethodType.CASH ? t("paymentMethods.fields.type.cash") : pm.type == PaymentMethodType.OTHER ? t("paymentMethods.fields.type.other") : pm.type}
-                                                        </SelectItem>
+                                        <FormLabel>{t("invoices.upsert.form.items.label")}</FormLabel>
+                                        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+                                            <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy}>
+                                                <div className="space-y-2">
+                                                    {fields.map((fieldItem, index) => (
+                                                        <SortableItem
+                                                            key={fieldItem.id}
+                                                            id={fieldItem.id}
+                                                            dragHandle={<GripVertical className="cursor-grab text-muted-foreground" />}
+                                                        >
+                                                            <div className="flex gap-2 items-center">
+                                                                <FormField
+                                                                    control={control}
+                                                                    name={`items.${index}.description`}
+                                                                    render={({ field }) => (
+                                                                        <FormItem>
+                                                                            <FormControl>
+                                                                                <Input
+                                                                                    {...field}
+                                                                                    placeholder={t(
+                                                                                        `invoices.upsert.form.items.description.placeholder`,
+                                                                                    )}
+                                                                                />
+                                                                            </FormControl>
+                                                                            <FormMessage />
+                                                                        </FormItem>
+                                                                    )}
+                                                                />
+
+                                                                <FormField
+                                                                    control={control}
+                                                                    name={`items.${index}.type`}
+                                                                    render={({ field }) => (
+                                                                        <FormItem>
+                                                                            <FormControl>
+                                                                                <Select value={field.value ?? 'SERVICE'} onValueChange={(val) => field.onChange(val as any)}>
+                                                                                    <SelectTrigger className="w-32 mb-0" aria-label={t("invoices.upsert.form.items.type.label") as string}>
+                                                                                        <SelectValue />
+                                                                                    </SelectTrigger>
+                                                                                    <SelectContent>
+                                                                                        <SelectItem value="HOUR">{t("invoices.upsert.form.items.type.hour")}</SelectItem>
+                                                                                        <SelectItem value="DAY">{t("invoices.upsert.form.items.type.day")}</SelectItem>
+                                                                                        <SelectItem value="DEPOSIT">{t("invoices.upsert.form.items.type.deposit")}</SelectItem>
+                                                                                        <SelectItem value="SERVICE">{t("invoices.upsert.form.items.type.service")}</SelectItem>
+                                                                                        <SelectItem value="PRODUCT">{t("invoices.upsert.form.items.type.product")}</SelectItem>
+                                                                                    </SelectContent>
+                                                                                </Select>
+                                                                            </FormControl>
+                                                                            <FormMessage />
+                                                                        </FormItem>
+                                                                    )}
+                                                                />
+
+                                                                <FormField
+                                                                    control={control}
+                                                                    name={`items.${index}.quantity`}
+                                                                    render={({ field }) => (
+                                                                        <FormItem>
+                                                                            <FormControl>
+                                                                                <BetterInput
+                                                                                    {...field}
+                                                                                    defaultValue={field.value || ""}
+                                                                                    postAdornment={t(`invoices.upsert.form.items.quantity.unit`)}
+                                                                                    type="number"
+                                                                                    step="0.001"
+                                                                                    placeholder={t(
+                                                                                        `invoices.upsert.form.items.quantity.placeholder`,
+                                                                                    )}
+                                                                                    onChange={(e) =>
+                                                                                        field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
+                                                                                    }
+                                                                                />
+                                                                            </FormControl>
+                                                                            <FormMessage />
+                                                                        </FormItem>
+                                                                    )}
+                                                                />
+
+                                                                <FormField
+                                                                    control={control}
+                                                                    name={`items.${index}.unitPrice`}
+                                                                    render={({ field }) => (
+                                                                        <FormItem>
+                                                                            <FormControl>
+                                                                                <BetterInput
+                                                                                    {...field}
+                                                                                    defaultValue={field.value || ""}
+                                                                                    postAdornment="$"
+                                                                                    type="number"
+                                                                                    step="0.01"
+                                                                                    placeholder={t(
+                                                                                        `invoices.upsert.form.items.unitPrice.placeholder`,
+                                                                                    )}
+                                                                                    onChange={(e) =>
+                                                                                        field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
+                                                                                    }
+                                                                                />
+                                                                            </FormControl>
+                                                                            <FormMessage />
+                                                                        </FormItem>
+                                                                    )}
+                                                                />
+
+                                                                <FormField
+                                                                    control={control}
+                                                                    name={`items.${index}.vatRate`}
+                                                                    render={({ field }) => (
+                                                                        <FormItem>
+                                                                            <FormControl>
+                                                                                <BetterInput
+                                                                                    {...field}
+                                                                                    defaultValue={field.value || 0}
+                                                                                    postAdornment="%"
+                                                                                    type="number"
+                                                                                    step="0.01"
+                                                                                    placeholder={t(
+                                                                                        `invoices.upsert.form.items.vatRate.placeholder`,
+                                                                                    )}
+                                                                                    onChange={(e) =>
+                                                                                        field.onChange(
+                                                                                            e.target.value === ""
+                                                                                                ? undefined
+                                                                                                : Number.parseFloat(e.target.value.replace(",", ".")),
+                                                                                        )
+                                                                                    }
+                                                                                />
+                                                                            </FormControl>
+                                                                            <FormMessage />
+                                                                        </FormItem>
+                                                                    )}
+                                                                />
+
+                                                                <Button variant={"outline"} onClick={() => onRemove(index)}>
+                                                                    <Trash2 className="h-4 w-4 text-red-700" />
+                                                                </Button>
+                                                            </div>
+                                                        </SortableItem>
                                                     ))}
-                                                </SelectContent>
-                                            </Select>
-                                        </FormControl>
-                                        <FormDescription>
-                                            {t("invoices.upsert.form.paymentMethod.description")}
-                                        </FormDescription>
-                                        <FormMessage />
+                                                </div>
+                                            </SortableContext>
+                                        </DndContext>
+
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            onClick={() =>
+                                                append({
+                                                    description: "",
+                                                    quantity: Number.NaN,
+                                                    unitPrice: Number.NaN,
+                                                    vatRate: Number.NaN,
+                                                    type: 'SERVICE',
+                                                    order: fields.length,
+                                                })
+                                            }
+                                        >
+                                            <Plus className="mr-2 h-4 w-4" />
+                                            {t("invoices.upsert.form.items.addItem")}
+                                        </Button>
                                     </FormItem>
-                                )}
-                            />
+                                </form>
+                            </Form>
+                        ) : (
+                            <Form {...recurringForm}>
+                                <form id="recurring-invoice-form" onSubmit={handleRecurringSubmit(onSubmitRecurring)} className="space-y-4" data-cy="recurring-invoice-form">
+                                    <FormField
+                                        control={recurringControl}
+                                        name="quoteId"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel>{t("recurringInvoices.upsert.form.quote.label")}</FormLabel>
+                                                <FormControl>
+                                                    <SearchSelect
+                                                        options={(quotes || []).map((c) => ({
+                                                            label: `${c.number}${c.title ? ` (${c.title})` : ""}`,
+                                                            value: c.id,
+                                                        }))}
+                                                        value={field.value ?? ""}
+                                                        onValueChange={(val) => {
+                                                            field.onChange(val || null)
+                                                            if (val) {
+                                                                const quote = quotes?.find((q) => q.id === val)
+                                                                if (!quote) return
+                                                                recurringForm.setValue("clientId", quote.clientId)
+                                                                recurringForm.setValue("notes", quote.notes)
+                                                                recurringForm.setValue("paymentMethodId", quote.paymentMethodId ?? quote.paymentMethod?.id ?? "")
+                                                                recurringForm.setValue("currency", quote.currency || "")
+                                                                recurringForm.setValue('items', quote.items.map((item) => ({
+                                                                    id: item.id,
+                                                                    type: item.type,
+                                                                    description: item.description || "",
+                                                                    quantity: item.quantity || 1,
+                                                                    unitPrice: item.unitPrice || 0,
+                                                                    vatRate: item.vatRate ?? 0,
+                                                                    order: item.order || 0,
+                                                                })))
+                                                            }
+                                                        }}
+                                                        onSearchChange={setQuoteSearchTerm}
+                                                        placeholder={t("recurringInvoices.upsert.form.quote.placeholder")}
+                                                    />
+                                                </FormControl>
+                                            </FormItem>
+                                        )}
+                                    />
 
+                                    <FormField
+                                        control={recurringControl}
+                                        name="clientId"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel required>{t("recurringInvoices.upsert.form.client.label")}</FormLabel>
+                                                <FormControl>
+                                                    <SearchSelect
+                                                        options={(clients || []).map((c) => ({ label: c.name || c.contactFirstname + " " + c.contactLastname, value: c.id }))}
+                                                        value={field.value ?? ""}
+                                                        onValueChange={(val) => field.onChange(val || null)}
+                                                        onSearchChange={setClientsSearchTerm}
+                                                        placeholder={t("recurringInvoices.upsert.form.client.placeholder")}
+                                                        data-cy="recurring-invoice-client-select"
+                                                        noResultsComponent={
+                                                            <Button
+                                                                variant="link"
+                                                                onClick={() => setClientDialogOpen(true)}
+                                                            >
+                                                                {t("recurringInvoices.upsert.form.client.noOptions")}
+                                                            </Button>
+                                                        }
+                                                    />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
 
-                            <FormItem>
-                                <FormLabel>{t("invoices.upsert.form.items.label")}</FormLabel>
-                                <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
-                                    <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy}>
-                                        <div className="space-y-2">
-                                            {fields.map((fieldItem, index) => (
-                                                <SortableItem
-                                                    key={fieldItem.id}
-                                                    id={fieldItem.id}
-                                                    dragHandle={<GripVertical className="cursor-grab text-muted-foreground" />}
-                                                >
-                                                    <div className="flex gap-2 items-center">
-                                                        <FormField
-                                                            control={control}
-                                                            name={`items.${index}.description`}
-                                                            render={({ field }) => (
-                                                                <FormItem>
-                                                                    <FormControl>
-                                                                        <Input
-                                                                            {...field}
-                                                                            placeholder={t(
-                                                                                `invoices.upsert.form.items.description.placeholder`,
-                                                                            )}
-                                                                        />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
+                                    <FormField
+                                        control={recurringControl}
+                                        name="currency"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel>{t("recurringInvoices.upsert.form.currency.label")}</FormLabel>
+                                                <FormControl>
+                                                    <CurrencySelect value={field.value} onChange={(value) => field.onChange(value)} data-cy="recurring-invoice-currency-select" />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+
+                                    <FormField
+                                        control={recurringControl}
+                                        name="notes"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel>{t("recurringInvoices.upsert.form.notes.label")}</FormLabel>
+                                                <FormControl>
+                                                    <Textarea {...field} placeholder={t("recurringInvoices.upsert.form.notes.placeholder")} className="max-h-40" />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+
+                                    <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                        <FormField
+                                            control={recurringControl}
+                                            name="paymentMethodId"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormLabel required>{t("recurringInvoices.upsert.form.paymentMethod.label")}</FormLabel>
+                                                    <FormControl>
+                                                        <Select value={field.value ?? ""} onValueChange={(val) => field.onChange(val || "")}>
+                                                            <SelectTrigger>
+                                                                <SelectValue placeholder={t("recurringInvoices.upsert.form.paymentMethod.placeholder")} />
+                                                            </SelectTrigger>
+                                                            <SelectContent>
+                                                                {paymentMethods?.map((pm: PaymentMethod) => (
+                                                                    <SelectItem key={pm.id} value={pm.id}>
+                                                                        {pm.name} - {pm.type == PaymentMethodType.BANK_TRANSFER ? t("paymentMethods.fields.type.bank_transfer") : pm.type == PaymentMethodType.PAYPAL ? t("paymentMethods.fields.type.paypal") : pm.type == PaymentMethodType.CHECK ? t("paymentMethods.fields.type.check") : pm.type == PaymentMethodType.CASH ? t("paymentMethods.fields.type.cash") : pm.type == PaymentMethodType.OTHER ? t("paymentMethods.fields.type.other") : pm.type}
+                                                                    </SelectItem>
+                                                                ))}
+                                                            </SelectContent>
+                                                        </Select>
+                                                    </FormControl>
+                                                    <FormDescription>
+                                                        {t("recurringInvoices.upsert.form.paymentMethod.description")}
+                                                    </FormDescription>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </section>
+
+                                    <Separator className="my-4" />
+
+                                    <section className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                        <FormField
+                                            control={recurringControl}
+                                            name="frequency"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormLabel required>
+                                                        {t("recurringInvoices.upsert.form.frequency.label")}
+                                                    </FormLabel>
+                                                    <FormControl>
+                                                        <Select value={field.value} onValueChange={field.onChange}>
+                                                            <SelectTrigger>
+                                                                <SelectValue placeholder={t("recurringInvoices.upsert.form.frequency.placeholder")} />
+                                                            </SelectTrigger>
+                                                            <SelectContent>
+                                                                <SelectItem value="WEEKLY">{t("recurringInvoices.frequency.weekly")}</SelectItem>
+                                                                <SelectItem value="BIWEEKLY">{t("recurringInvoices.frequency.biweekly")}</SelectItem>
+                                                                <SelectItem value="MONTHLY">{t("recurringInvoices.frequency.monthly")}</SelectItem>
+                                                                <SelectItem value="BIMONTHLY">{t("recurringInvoices.frequency.bimonthly")}</SelectItem>
+                                                                <SelectItem value="QUARTERLY">{t("recurringInvoices.frequency.quarterly")}</SelectItem>
+                                                                <SelectItem value="QUADMONTHLY">{t("recurringInvoices.frequency.quadmonthly")}</SelectItem>
+                                                                <SelectItem value="SEMIANNUALLY">{t("recurringInvoices.frequency.semiannually")}</SelectItem>
+                                                                <SelectItem value="ANNUALLY">{t("recurringInvoices.frequency.annually")}</SelectItem>
+                                                            </SelectContent>
+                                                        </Select>
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                    <FormDescription>
+                                                        {t("recurringInvoices.upsert.form.frequency.description")}
+                                                    </FormDescription>
+                                                </FormItem>
+                                            )}
+                                        />
+
+                                        <FormField
+                                            control={recurringControl}
+                                            name="count"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormLabel>
+                                                        {t("recurringInvoices.upsert.form.count.label")}
+                                                    </FormLabel>
+                                                    <FormControl>
+                                                        <BetterInput
+                                                            {...field}
+                                                            type="number"
+                                                            placeholder={t("recurringInvoices.upsert.form.count.placeholder")}
+                                                            onChange={(e) =>
+                                                                field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
+                                                            }
                                                         />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                    <FormDescription>
+                                                        {t("recurringInvoices.upsert.form.count.description")}
+                                                    </FormDescription>
+                                                </FormItem>
+                                            )}
+                                        />
 
-                                                        <FormField
-                                                            control={control}
-                                                            name={`items.${index}.type`}
-                                                            render={({ field }) => (
-                                                                <FormItem>
-                                                                    <FormControl>
-                                                                        <Select value={field.value ?? 'SERVICE'} onValueChange={(val) => field.onChange(val as any)}>
-                                                                            <SelectTrigger className="w-32 mb-0" aria-label={t("invoices.upsert.form.items.type.label") as string}>
-                                                                                <SelectValue />
-                                                                            </SelectTrigger>
-                                                                            <SelectContent>
-                                                                                <SelectItem value="HOUR">{t("invoices.upsert.form.items.type.hour")}</SelectItem>
-                                                                                <SelectItem value="DAY">{t("invoices.upsert.form.items.type.day")}</SelectItem>
-                                                                                <SelectItem value="DEPOSIT">{t("invoices.upsert.form.items.type.deposit")}</SelectItem>
-                                                                                <SelectItem value="SERVICE">{t("invoices.upsert.form.items.type.service")}</SelectItem>
-                                                                                <SelectItem value="PRODUCT">{t("invoices.upsert.form.items.type.product")}</SelectItem>
-                                                                            </SelectContent>
-                                                                        </Select>
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
+                                        <FormField
+                                            control={recurringControl}
+                                            name="until"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormLabel>
+                                                        {t("recurringInvoices.upsert.form.until.label")}
+                                                    </FormLabel>
+                                                    <FormControl>
+                                                        <DatePicker
+                                                            {...field}
+                                                            className="w-full"
+                                                            placeholder={t("recurringInvoices.upsert.form.until.placeholder")}
+                                                            value={field.value || null}
+                                                            onChange={field.onChange}
                                                         />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                    <FormDescription>
+                                                        {t("recurringInvoices.upsert.form.until.description")}
+                                                    </FormDescription>
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </section>
 
-                                                        <FormField
-                                                            control={control}
-                                                            name={`items.${index}.quantity`}
-                                                            render={({ field }) => (
-                                                                <FormItem>
-                                                                    <FormControl>
-                                                                        <BetterInput
-                                                                            {...field}
-                                                                            defaultValue={field.value || ""}
-                                                                            postAdornment={t(`invoices.upsert.form.items.quantity.unit`)}
-                                                                            type="number"
-                                                                            step="0.001"
-                                                                            placeholder={t(
-                                                                                `invoices.upsert.form.items.quantity.placeholder`,
-                                                                            )}
-                                                                            onChange={(e) =>
-                                                                                field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                                                                            }
-                                                                        />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
+                                    <Separator className="my-4" />
 
-                                                        <FormField
-                                                            control={control}
-                                                            name={`items.${index}.unitPrice`}
-                                                            render={({ field }) => (
-                                                                <FormItem>
-                                                                    <FormControl>
-                                                                        <BetterInput
-                                                                            {...field}
-                                                                            defaultValue={field.value || ""}
-                                                                            postAdornment="$"
-                                                                            type="number"
-                                                                            step="0.01"
-                                                                            placeholder={t(
-                                                                                `invoices.upsert.form.items.unitPrice.placeholder`,
-                                                                            )}
-                                                                            onChange={(e) =>
-                                                                                field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                                                                            }
-                                                                        />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
+                                    <FormItem>
+                                        <FormLabel>{t("recurringInvoices.upsert.form.items.label")}</FormLabel>
+                                        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onRecurringDragEnd}>
+                                            <SortableContext items={recurringFields.map((f) => f.id)} strategy={verticalListSortingStrategy}>
+                                                <div className="space-y-2">
+                                                    {recurringFields.map((fieldItem, index) => (
+                                                        <SortableItem
+                                                            key={fieldItem.id}
+                                                            id={fieldItem.id}
+                                                            dragHandle={<GripVertical className="cursor-grab text-muted-foreground" />}
+                                                        >
+                                                            <div className="flex gap-2 items-center">
+                                                                <FormField
+                                                                    control={recurringControl}
+                                                                    name={`items.${index}.description`}
+                                                                    render={({ field }) => (
+                                                                        <FormItem>
+                                                                            <FormControl>
+                                                                                <Input
+                                                                                    {...field}
+                                                                                    placeholder={t(
+                                                                                        "recurringInvoices.upsert.form.items.description.placeholder",
+                                                                                    )}
+                                                                                />
+                                                                            </FormControl>
+                                                                            <FormMessage />
+                                                                        </FormItem>
+                                                                    )}
+                                                                />
 
-                                                        <FormField
-                                                            control={control}
-                                                            name={`items.${index}.vatRate`}
-                                                            render={({ field }) => (
-                                                                <FormItem>
-                                                                    <FormControl>
-                                                                        <BetterInput
-                                                                            {...field}
-                                                                            defaultValue={field.value || 0}
-                                                                            postAdornment="%"
-                                                                            type="number"
-                                                                            step="0.01"
-                                                                            placeholder={t(
-                                                                                `invoices.upsert.form.items.vatRate.placeholder`,
-                                                                            )}
-                                                                            onChange={(e) =>
-                                                                                field.onChange(
-                                                                                    e.target.value === ""
-                                                                                        ? undefined
-                                                                                        : Number.parseFloat(e.target.value.replace(",", ".")),
-                                                                                )
-                                                                            }
-                                                                        />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
+                                                                <FormField
+                                                                    control={recurringControl}
+                                                                    name={`items.${index}.type`}
+                                                                    render={({ field }) => (
+                                                                        <FormItem>
+                                                                            <FormControl>
+                                                                                <Select value={field.value ?? 'SERVICE'} onValueChange={(val) => field.onChange(val as any)}>
+                                                                                    <SelectTrigger className="w-32" size="sm" aria-label={t("recurringInvoices.upsert.form.items.type.label") as string}>
+                                                                                        <SelectValue />
+                                                                                    </SelectTrigger>
+                                                                                    <SelectContent>
+                                                                                        <SelectItem value="HOUR">{t("recurringInvoices.upsert.form.items.type.hour")}</SelectItem>
+                                                                                        <SelectItem value="DAY">{t("recurringInvoices.upsert.form.items.type.day")}</SelectItem>
+                                                                                        <SelectItem value="DEPOSIT">{t("recurringInvoices.upsert.form.items.type.deposit")}</SelectItem>
+                                                                                        <SelectItem value="SERVICE">{t("recurringInvoices.upsert.form.items.type.service")}</SelectItem>
+                                                                                        <SelectItem value="PRODUCT">{t("recurringInvoices.upsert.form.items.type.product")}</SelectItem>
+                                                                                    </SelectContent>
+                                                                                </Select>
+                                                                            </FormControl>
+                                                                            <FormMessage />
+                                                                        </FormItem>
+                                                                    )}
+                                                                />
 
-                                                        <Button variant={"outline"} onClick={() => onRemove(index)}>
-                                                            <Trash2 className="h-4 w-4 text-red-700" />
-                                                        </Button>
-                                                    </div>
-                                                </SortableItem>
-                                            ))}
-                                        </div>
-                                    </SortableContext>
-                                </DndContext>
+                                                                <FormField
+                                                                    control={recurringControl}
+                                                                    name={`items.${index}.quantity`}
+                                                                    render={({ field }) => (
+                                                                        <FormItem>
+                                                                            <FormControl>
+                                                                                <BetterInput
+                                                                                    {...field}
+                                                                                    defaultValue={field.value || ""}
+                                                                                    postAdornment={t("recurringInvoices.upsert.form.items.quantity.unit")}
+                                                                                    type="number"
+                                                                                    step="0.001"
+                                                                                    placeholder={t(
+                                                                                        "recurringInvoices.upsert.form.items.quantity.placeholder",
+                                                                                    )}
+                                                                                    onChange={(e) =>
+                                                                                        field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
+                                                                                    }
+                                                                                />
+                                                                            </FormControl>
+                                                                            <FormMessage />
+                                                                        </FormItem>
+                                                                    )}
+                                                                />
 
-                                <Button
-                                    type="button"
-                                    variant="outline"
-                                    onClick={() =>
-                                        append({
-                                            description: "",
-                                            quantity: Number.NaN,
-                                            unitPrice: Number.NaN,
-                                            vatRate: Number.NaN,
-                                            type: 'SERVICE',
-                                            order: fields.length,
-                                        })
-                                    }
-                                >
-                                    <Plus className="mr-2 h-4 w-4" />
-                                    {t("invoices.upsert.form.items.addItem")}
-                                </Button>
-                            </FormItem>
+                                                                <FormField
+                                                                    control={recurringControl}
+                                                                    name={`items.${index}.unitPrice`}
+                                                                    render={({ field }) => (
+                                                                        <FormItem>
+                                                                            <FormControl>
+                                                                                <BetterInput
+                                                                                    {...field}
+                                                                                    defaultValue={field.value || ""}
+                                                                                    postAdornment="$"
+                                                                                    type="number"
+                                                                                    step="0.01"
+                                                                                    placeholder={t(
+                                                                                        "recurringInvoices.upsert.form.items.unitPrice.placeholder",
+                                                                                    )}
+                                                                                    onChange={(e) =>
+                                                                                        field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
+                                                                                    }
+                                                                                />
+                                                                            </FormControl>
+                                                                            <FormMessage />
+                                                                        </FormItem>
+                                                                    )}
+                                                                />
 
-                            <div className="flex justify-end space-x-2">
-                                <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                                    {t("invoices.upsert.actions.cancel")}
-                                </Button>
-                                <Button type="submit" dataCy="invoice-submit">
-                                    {t(`invoices.upsert.actions.${isEdit ? "save" : "create"}`)}
-                                </Button>
-                            </div>
-                        </form>
-                    </Form>
+                                                                <FormField
+                                                                    control={recurringControl}
+                                                                    name={`items.${index}.vatRate`}
+                                                                    render={({ field }) => (
+                                                                        <FormItem>
+                                                                            <FormControl>
+                                                                                <BetterInput
+                                                                                    {...field}
+                                                                                    defaultValue={field.value || 0}
+                                                                                    postAdornment="%"
+                                                                                    type="number"
+                                                                                    step="0.01"
+                                                                                    placeholder={t(
+                                                                                        "recurringInvoices.upsert.form.items.vatRate.placeholder",
+                                                                                    )}
+                                                                                    onChange={(e) =>
+                                                                                        field.onChange(
+                                                                                            e.target.value === ""
+                                                                                                ? undefined
+                                                                                                : Number.parseFloat(e.target.value.replace(",", ".")),
+                                                                                        )
+                                                                                    }
+                                                                                />
+                                                                            </FormControl>
+                                                                            <FormMessage />
+                                                                        </FormItem>
+                                                                    )}
+                                                                />
+
+                                                                <Button variant={"outline"} onClick={() => onRemoveRecurring(index)}>
+                                                                    <Trash2 className="h-4 w-4 text-red-700" />
+                                                                </Button>
+                                                            </div>
+                                                        </SortableItem>
+                                                    ))}
+                                                </div>
+                                            </SortableContext>
+                                        </DndContext>
+
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            onClick={() =>
+                                                appendRecurring({
+                                                    description: "",
+                                                    type: "HOUR",
+                                                    quantity: Number.NaN,
+                                                    unitPrice: Number.NaN,
+                                                    vatRate: Number.NaN,
+                                                    order: recurringFields.length,
+                                                })
+                                            }
+                                        >
+                                            <Plus className="mr-2 h-4 w-4" />
+                                            {t("recurringInvoices.upsert.form.items.addItem")}
+                                        </Button>
+                                    </FormItem>
+
+                                    <Separator className="my-4" />
+
+                                    <FormField
+                                        control={recurringControl}
+                                        name="autoSend"
+                                        render={({ field }) => (
+                                            <FormItem className="mt-4">
+                                                <Switch
+                                                    id="autoSend"
+                                                    checked={field.value}
+                                                    onCheckedChange={field.onChange}
+                                                />
+                                                <FormLabel className="ml-2" htmlFor="autoSend">
+                                                    {t("recurringInvoices.upsert.form.autoSend.label")}
+                                                </FormLabel>
+                                                <FormDescription>
+                                                    {t("recurringInvoices.upsert.form.autoSend.description")}
+                                                </FormDescription>
+                                            </FormItem>
+                                        )}
+                                    />
+                                </form>
+                            </Form>
+                        )}
+                    </div>
+
+                    <div className="shrink-0 border-t px-6 py-4 flex justify-end space-x-2">
+                        <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                            {t("invoices.upsert.actions.cancel")}
+                        </Button>
+                        <Button
+                            type="submit"
+                            form={mode === "invoice" ? "invoice-form" : "recurring-invoice-form"}
+                            dataCy="invoice-submit"
+                        >
+                            {mode === "invoice"
+                                ? t(`invoices.upsert.actions.${isEdit ? "save" : "create"}`)
+                                : t("recurringInvoices.upsert.actions.create")}
+                        </Button>
+                    </div>
                 </DialogContent>
             </Dialog>
 

--- a/frontend/src/pages/(app)/invoices/index.tsx
+++ b/frontend/src/pages/(app)/invoices/index.tsx
@@ -124,9 +124,9 @@ export default function Invoices() {
 
             <Tabs value={filter} onValueChange={(value) => setFilter(value as InvoiceFilter)}>
                 <TabsList>
-                    <TabsTrigger value="all">{t("invoices.filters.all")}</TabsTrigger>
-                    <TabsTrigger value="oneTime">{t("invoices.filters.oneTime")}</TabsTrigger>
-                    <TabsTrigger value="recurring">{t("invoices.filters.recurring")}</TabsTrigger>
+                    <TabsTrigger value="all" data-cy="invoice-filter-all">{t("invoices.filters.all")}</TabsTrigger>
+                    <TabsTrigger value="oneTime" data-cy="invoice-filter-oneTime">{t("invoices.filters.oneTime")}</TabsTrigger>
+                    <TabsTrigger value="recurring" data-cy="invoice-filter-recurring">{t("invoices.filters.recurring")}</TabsTrigger>
                 </TabsList>
             </Tabs>
 

--- a/frontend/src/pages/(app)/invoices/index.tsx
+++ b/frontend/src/pages/(app)/invoices/index.tsx
@@ -7,15 +7,13 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { InvoiceStatus, type Invoice, type RecurringInvoice } from "@/types"
 import { usePageHeader } from "@/hooks/use-page-header"
 import { useTranslation } from "react-i18next"
-import { RecurringInvoiceUpsert } from "./_components/recurring-invoices/recurring-invoices-upsert"
 
 type InvoiceFilter = "all" | "oneTime" | "recurring"
-type InvoiceStatusFilter = "all" | "sent" | "paid"
+type InvoiceStatusFilter = "sent" | "paid" | "unpaid" | undefined
 
 export default function Invoices() {
     const { t } = useTranslation()
     const invoiceListRef = useRef<InvoiceListHandle>(null)
-    const [createRecurringInvoiceDialog, setCreateRecurringInvoiceDialog] = useState<boolean>(false)
 
     const [page, setPage] = useState(1)
     const {
@@ -44,17 +42,19 @@ export default function Invoices() {
 
     const [searchTerm, setSearchTerm] = useState("")
     const [filter, setFilter] = useState<InvoiceFilter>("all")
-    const [statusFilter, setStatusFilter] = useState<InvoiceStatusFilter>("all")
+    const [statusFilter, setStatusFilter] = useState<InvoiceStatusFilter>(undefined)
 
     const matchesSearch = (invoice: Invoice) =>
         invoice.title?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        invoice.status.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        invoice.rawNumber?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        invoice.number?.toString().includes(searchTerm) ||
         invoice.client?.name?.toLowerCase().includes(searchTerm.toLowerCase())
 
     const matchesStatus = (invoice: Invoice) =>
-        statusFilter === "all" ||
+        !statusFilter ||
         (statusFilter === "sent" && invoice.status === InvoiceStatus.SENT) ||
-        (statusFilter === "paid" && invoice.status === InvoiceStatus.PAID)
+        (statusFilter === "paid" && invoice.status === InvoiceStatus.PAID) ||
+        (statusFilter === "unpaid" && (invoice.status === InvoiceStatus.UNPAID || invoice.status === InvoiceStatus.OVERDUE))
 
     const upcomingInvoices: Invoice[] = (recurringInvoices?.data || [])
         .filter((recurringInvoice) => !!recurringInvoice.nextInvoiceDate)
@@ -82,20 +82,20 @@ export default function Invoices() {
             isActive: true,
         }))
 
-    const filteredInvoices =
-        filter === "recurring"
-            ? [
-                ...upcomingInvoices.filter((invoice) => matchesSearch(invoice) && matchesStatus(invoice)),
-                ...(invoices?.invoices.filter((invoice) => !!invoice.recurringInvoiceId).filter((invoice) => matchesSearch(invoice) && matchesStatus(invoice)) || []),
-            ]
-            : (invoices?.invoices.filter(
-                (invoice) => matchesSearch(invoice) && matchesStatus(invoice) && (filter === "all" || !invoice.recurringInvoiceId),
-            ) || [])
+    const filteredInvoices = [
+        ...(invoices?.invoices.filter(
+            (invoice) =>
+                matchesSearch(invoice) &&
+                matchesStatus(invoice) &&
+                (filter === "all" || (filter === "recurring" ? !!invoice.recurringInvoiceId : !invoice.recurringInvoiceId)),
+        ) || []),
+        ...(filter !== "oneTime" ? upcomingInvoices.filter((invoice) => matchesSearch(invoice) && matchesStatus(invoice)) : []),
+    ]
 
     const invoiceStatusCounts = {
-        all: invoices?.invoices.length || 0,
         sent: invoices?.invoices.filter((i) => i.status === InvoiceStatus.SENT).length || 0,
         paid: invoices?.invoices.filter((i) => i.status === InvoiceStatus.PAID).length || 0,
+        unpaid: invoices?.invoices.filter((i) => i.status === InvoiceStatus.UNPAID || i.status === InvoiceStatus.OVERDUE).length || 0,
     }
 
     usePageHeader(t("sidebar.navigation.invoices"))
@@ -144,12 +144,6 @@ export default function Invoices() {
                 setPage={setPage}
                 emptyState={invoiceEmptyState}
                 showCreateButton={true}
-                onAddClick={() => (filter === "recurring" ? setCreateRecurringInvoiceDialog(true) : invoiceListRef.current?.handleAddClick())}
-            />
-
-            <RecurringInvoiceUpsert
-                open={createRecurringInvoiceDialog}
-                onOpenChange={setCreateRecurringInvoiceDialog}
             />
         </div>
     )

--- a/frontend/src/pages/(app)/invoices/index.tsx
+++ b/frontend/src/pages/(app)/invoices/index.tsx
@@ -1,18 +1,21 @@
-import { ReceiptText, Plus, Search } from "lucide-react"
-import { Card, CardContent } from "@/components/ui/card"
+import { ReceiptText, Plus } from "lucide-react"
 import { InvoiceList, type InvoiceListHandle } from "@/pages/(app)/invoices/_components/invoice-list"
 import { useEffect, useRef, useState } from "react"
 import { useGetRaw, useSse } from "@/hooks/use-fetch"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import type { Invoice, RecurringInvoice } from "@/types"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { InvoiceStatus, type Invoice, type RecurringInvoice } from "@/types"
+import { usePageHeader } from "@/hooks/use-page-header"
 import { useTranslation } from "react-i18next"
-import { RecurringInvoiceList, type RecurringInvoiceListHandle } from "./_components/recurring-invoices/recurring-invoices-list"
+import { RecurringInvoiceUpsert } from "./_components/recurring-invoices/recurring-invoices-upsert"
+
+type InvoiceFilter = "all" | "oneTime" | "recurring"
+type InvoiceStatusFilter = "all" | "sent" | "paid"
 
 export default function Invoices() {
     const { t } = useTranslation()
     const invoiceListRef = useRef<InvoiceListHandle>(null)
-    const recurringInvoiceListRef = useRef<RecurringInvoiceListHandle>(null)
+    const [createRecurringInvoiceDialog, setCreateRecurringInvoiceDialog] = useState<boolean>(false)
 
     const [page, setPage] = useState(1)
     const {
@@ -40,13 +43,62 @@ export default function Invoices() {
     }, [downloadInvoicePdf, pdf])
 
     const [searchTerm, setSearchTerm] = useState("")
+    const [filter, setFilter] = useState<InvoiceFilter>("all")
+    const [statusFilter, setStatusFilter] = useState<InvoiceStatusFilter>("all")
+
+    const matchesSearch = (invoice: Invoice) =>
+        invoice.title?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        invoice.status.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        invoice.client?.name?.toLowerCase().includes(searchTerm.toLowerCase())
+
+    const matchesStatus = (invoice: Invoice) =>
+        statusFilter === "all" ||
+        (statusFilter === "sent" && invoice.status === InvoiceStatus.SENT) ||
+        (statusFilter === "paid" && invoice.status === InvoiceStatus.PAID)
+
+    const upcomingInvoices: Invoice[] = (recurringInvoices?.data || [])
+        .filter((recurringInvoice) => !!recurringInvoice.nextInvoiceDate)
+        .map((recurringInvoice) => ({
+            id: `upcoming-${recurringInvoice.id}`,
+            number: 0,
+            recurringInvoiceId: recurringInvoice.id,
+            clientId: recurringInvoice.clientId,
+            companyId: recurringInvoice.companyId,
+            client: recurringInvoice.client,
+            company: recurringInvoice.company,
+            items: [],
+            status: InvoiceStatus.UPCOMING,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            dueDate: new Date(recurringInvoice.nextInvoiceDate!).toISOString(),
+            paymentMethodId: recurringInvoice.paymentMethodId,
+            paymentMethod: recurringInvoice.paymentMethod,
+            notes: recurringInvoice.notes,
+            discountRate: 0,
+            totalHT: recurringInvoice.totalHT,
+            totalVAT: recurringInvoice.totalVAT,
+            totalTTC: recurringInvoice.totalTTC,
+            currency: recurringInvoice.currency,
+            isActive: true,
+        }))
 
     const filteredInvoices =
-        invoices?.invoices.filter(
-            (invoice) =>
-                invoice.title?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                invoice.status.toLowerCase().includes(searchTerm.toLowerCase()),
-        ) || []
+        filter === "recurring"
+            ? [
+                ...upcomingInvoices.filter((invoice) => matchesSearch(invoice) && matchesStatus(invoice)),
+                ...(invoices?.invoices.filter((invoice) => !!invoice.recurringInvoiceId).filter((invoice) => matchesSearch(invoice) && matchesStatus(invoice)) || []),
+            ]
+            : (invoices?.invoices.filter(
+                (invoice) => matchesSearch(invoice) && matchesStatus(invoice) && (filter === "all" || !invoice.recurringInvoiceId),
+            ) || [])
+
+    const invoiceStatusCounts = {
+        all: invoices?.invoices.length || 0,
+        sent: invoices?.invoices.filter((i) => i.status === InvoiceStatus.SENT).length || 0,
+        paid: invoices?.invoices.filter((i) => i.status === InvoiceStatus.PAID).length || 0,
+    }
+
+    usePageHeader(t("sidebar.navigation.invoices"))
 
     const invoiceEmptyState = (
         <div className="text-center py-12">
@@ -67,136 +119,37 @@ export default function Invoices() {
             )}
         </div>
     )
-    const recurringInvoiceEmptyState = (
-        <div className="text-center py-12">
-            <ReceiptText className="mx-auto h-12 w-12 text-gray-400" />
-            <h3 className="mt-2 text-sm font-medium text-foreground">
-                {t("recurringInvoices.emptyState.noInvoices")}
-            </h3>
-            <p className="mt-1 text-sm text-primary">
-                {t("recurringInvoices.emptyState.startAdding")}
-            </p>
-            <div className="mt-6">
-                <Button onClick={() => recurringInvoiceListRef.current?.handleAddClick()}>
-                    <Plus className="h-4 w-4 mr-2" />
-                    {t("recurringInvoices.actions.addNew")}
-                </Button>
-            </div>
-        </div>
-    )
-
     return (
         <div className="max-w-7xl mx-auto space-y-6 p-6">
-            <div className="flex flex-col lg:flex-row items-start lg:items-center gap-4 lg:gap-0 lg:justify-between">
-                <div className="flex items-center space-x-3">
-                    <div className="p-2 bg-blue-100 rounded-lg">
-                        <ReceiptText className="h-5 w-5 text-blue-600" />
-                    </div>
-                    <div>
-                        <div className="text-sm text-primary">{t("invoices.header.subtitle")}</div>
-                        <div className="font-medium text-foreground">
-                            {t("invoices.header.count", {
-                                count: filteredInvoices.length,
-                                found: searchTerm ? t("invoices.header.found") : "",
-                            })}
-                        </div>
-                    </div>
-                </div>
 
-                <div className="flex flex-row items-center gap-4 w-full lg:w-fit lg:gap-6 lg:justify-between">
-                    <div className="relative w-full lg:w-fit">
-                        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-                        <Input
-                            placeholder={t("invoices.search.placeholder")}
-                            value={searchTerm}
-                            onChange={(e) => setSearchTerm(e.target.value)}
-                            className="pl-10 w-full"
-                        />
-                    </div>
-                    <Button onClick={() => invoiceListRef.current?.handleAddClick()}>
-                        <Plus className="h-4 w-4 mr-0 md:mr-2" />
-                        <span className="hidden md:inline-flex">{t("invoices.actions.addNew")}</span>
-                    </Button>
-                </div>
-            </div>
-
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-                <Card>
-                    <CardContent>
-                        <div className="flex items-center space-x-4">
-                            <div className="p-3 bg-blue-100 rounded-lg">
-                                <ReceiptText className="h-6 w-6 text-blue-600" />
-                            </div>
-                            <div>
-                                <p className="text-2xl font-semibold text-foreground">{invoices?.invoices.length || 0}</p>
-                                <p className="text-sm text-primary">{t("invoices.stats.total")}</p>
-                            </div>
-                        </div>
-                    </CardContent>
-                </Card>
-
-                <Card>
-                    <CardContent>
-                        <div className="flex items-center space-x-4">
-                            <div className="p-3 bg-yellow-100 rounded-lg">
-                                <div className="w-6 h-6 flex items-center justify-center">
-                                    <div className="w-3 h-3 bg-yellow-500 rounded-full"></div>
-                                </div>
-                            </div>
-                            <div>
-                                <p className="text-2xl font-semibold text-foreground">
-                                    {invoices?.invoices.filter((c) => c.status === "SENT").length || 0}
-                                </p>
-                                <p className="text-sm text-primary">{t("invoices.stats.sent")}</p>
-                            </div>
-                        </div>
-                    </CardContent>
-                </Card>
-
-                <Card>
-                    <CardContent>
-                        <div className="flex items-center space-x-4">
-                            <div className="p-3 bg-blue-100 rounded-lg">
-                                <div className="w-6 h-6 flex items-center justify-center">
-                                    <div className="w-3 h-3 bg-blue-500 rounded-full"></div>
-                                </div>
-                            </div>
-                            <div>
-                                <p className="text-2xl font-semibold text-foreground">
-                                    {invoices?.invoices.filter((c) => c.status === "PAID").length || 0}
-                                </p>
-                                <p className="text-sm text-primary">{t("invoices.stats.paid")}</p>
-                            </div>
-                        </div>
-                    </CardContent>
-                </Card>
-            </div>
-
-            <RecurringInvoiceList
-                ref={recurringInvoiceListRef}
-                recurringInvoices={recurringInvoices?.data || []}
-                loading={false}
-                title={t("recurringInvoices.list.title")}
-                description={t("recurringInvoices.list.description")}
-                page={1}
-                pageCount={1}
-                setPage={() => { }}
-                mutate={() => { }}
-                emptyState={recurringInvoiceEmptyState}
-                showCreateButton={true}
-            />
+            <Tabs value={filter} onValueChange={(value) => setFilter(value as InvoiceFilter)}>
+                <TabsList>
+                    <TabsTrigger value="all">{t("invoices.filters.all")}</TabsTrigger>
+                    <TabsTrigger value="oneTime">{t("invoices.filters.oneTime")}</TabsTrigger>
+                    <TabsTrigger value="recurring">{t("invoices.filters.recurring")}</TabsTrigger>
+                </TabsList>
+            </Tabs>
 
             <InvoiceList
                 ref={invoiceListRef}
                 invoices={filteredInvoices}
                 loading={false}
-                title={t("invoices.list.title")}
-                description={t("invoices.list.description")}
+                searchTerm={searchTerm}
+                onSearchChange={setSearchTerm}
+                statusFilter={statusFilter}
+                onStatusFilterChange={setStatusFilter}
+                statusCounts={invoiceStatusCounts}
                 page={page}
                 pageCount={invoices?.pageCount || 1}
                 setPage={setPage}
                 emptyState={invoiceEmptyState}
                 showCreateButton={true}
+                onAddClick={() => (filter === "recurring" ? setCreateRecurringInvoiceDialog(true) : invoiceListRef.current?.handleAddClick())}
+            />
+
+            <RecurringInvoiceUpsert
+                open={createRecurringInvoiceDialog}
+                onOpenChange={setCreateRecurringInvoiceDialog}
             />
         </div>
     )

--- a/frontend/src/pages/(app)/payment-methods/_components/payment-method-list.tsx
+++ b/frontend/src/pages/(app)/payment-methods/_components/payment-method-list.tsx
@@ -1,8 +1,9 @@
-import { Banknote, Edit, Eye, Plus, Trash2 } from "lucide-react"
+import { Banknote, Edit, Eye, Plus, Search, Trash2 } from "lucide-react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { forwardRef, useImperativeHandle, useState } from "react"
 
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import { PaymentMethodDeleteDialog } from "./payment-method-delete"
 import { PaymentMethodUpsert } from "./payment-method-upsert"
 import { PaymentMethodViewDialog } from "./payment-method-view"
@@ -20,8 +21,10 @@ interface PaymentMethod {
 interface PaymentMethodsListProps {
   paymentMethods: PaymentMethod[]
   loading: boolean
-  title: string
-  description: string
+  title?: string
+  description?: string
+  searchTerm?: string
+  onSearchChange?: (value: string) => void
   page?: number
   pageCount?: number
   setPage?: (page: number) => void
@@ -35,7 +38,7 @@ export interface PaymentMethodsListHandle {
 }
 
 export const PaymentMethodsList = forwardRef<PaymentMethodsListHandle, PaymentMethodsListProps>(
-  ({ paymentMethods = [], loading, title, description, mutate, emptyState, showCreateButton = false }, ref) => {
+  ({ paymentMethods = [], loading, title, description, searchTerm, onSearchChange, mutate, emptyState, showCreateButton = false }, ref) => {
     const { t } = useTranslation()
     const [createDialog, setCreateDialog] = useState<boolean>(false)
     const [editDialog, setEditDialog] = useState<PaymentMethod | null>(null)
@@ -63,14 +66,25 @@ export const PaymentMethodsList = forwardRef<PaymentMethodsListHandle, PaymentMe
     return (
       <>
         <Card className="gap-0">
-          <CardHeader className="border-b flex flex-row items-center justify-between">
-            <div>
-              <CardTitle className="flex items-center space-x-2">
-                <Banknote className="h-5 w-5 " />
-                <span>{title}</span>
-              </CardTitle>
-              <CardDescription>{description}</CardDescription>
-            </div>
+          <CardHeader className="border-b flex flex-col sm:flex-row items-stretch sm:items-center gap-3 sm:justify-between">
+            {title ? (
+              <div>
+                <CardTitle className="flex items-center space-x-2">
+                  <span>{title}</span>
+                </CardTitle>
+                {description && <CardDescription>{description}</CardDescription>}
+              </div>
+            ) : onSearchChange ? (
+              <div className="relative w-full sm:w-fit sm:flex-1 sm:max-w-sm">
+                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+                <Input
+                  placeholder={t("paymentMethods.search.placeholder") || ""}
+                  value={searchTerm}
+                  onChange={(e) => onSearchChange(e.target.value)}
+                  className="pl-10 w-full"
+                />
+              </div>
+            ) : null}
             {showCreateButton && (
               <Button onClick={() => setCreateDialog(true)}>
                 <Plus className="h-4 w-4 mr-0 md:mr-2" />

--- a/frontend/src/pages/(app)/payment-methods/_components/payment-method-list.tsx
+++ b/frontend/src/pages/(app)/payment-methods/_components/payment-method-list.tsx
@@ -2,6 +2,7 @@ import { Banknote, Edit, Eye, Plus, Search, Trash2 } from "lucide-react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { forwardRef, useImperativeHandle, useState } from "react"
 
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { PaymentMethodDeleteDialog } from "./payment-method-delete"
@@ -25,6 +26,9 @@ interface PaymentMethodsListProps {
   description?: string
   searchTerm?: string
   onSearchChange?: (value: string) => void
+  statusFilter?: "active" | "inactive"
+  onStatusFilterChange?: (value: "active" | "inactive" | undefined) => void
+  statusCounts?: { active: number; inactive: number }
   page?: number
   pageCount?: number
   setPage?: (page: number) => void
@@ -38,7 +42,7 @@ export interface PaymentMethodsListHandle {
 }
 
 export const PaymentMethodsList = forwardRef<PaymentMethodsListHandle, PaymentMethodsListProps>(
-  ({ paymentMethods = [], loading, title, description, searchTerm, onSearchChange, mutate, emptyState, showCreateButton = false }, ref) => {
+  ({ paymentMethods = [], loading, title, description, searchTerm, onSearchChange, statusFilter, onStatusFilterChange, statusCounts, mutate, emptyState, showCreateButton = false }, ref) => {
     const { t } = useTranslation()
     const [createDialog, setCreateDialog] = useState<boolean>(false)
     const [editDialog, setEditDialog] = useState<PaymentMethod | null>(null)
@@ -85,12 +89,38 @@ export const PaymentMethodsList = forwardRef<PaymentMethodsListHandle, PaymentMe
                 />
               </div>
             ) : null}
-            {showCreateButton && (
-              <Button onClick={() => setCreateDialog(true)}>
-                <Plus className="h-4 w-4 mr-0 md:mr-2" />
-                <span className="hidden md:inline-flex">{t("paymentMethods.list.add")}</span>
-              </Button>
-            )}
+            <div className="flex items-center gap-2 sm:ml-auto">
+              {onStatusFilterChange && (
+                <div className="flex items-center gap-2">
+                  <Badge
+                    onClick={() => onStatusFilterChange(statusFilter === "active" ? undefined : "active")}
+                    variant="outline"
+                    className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter === "active"
+                      ? "bg-green-600 text-white font-semibold shadow-sm scale-105"
+                      : "bg-green-50 text-green-700/70 hover:bg-green-100"
+                      }`}
+                  >
+                    {t("clients.stats.active")} ({statusCounts?.active ?? 0})
+                  </Badge>
+                  <Badge
+                    onClick={() => onStatusFilterChange(statusFilter === "inactive" ? undefined : "inactive")}
+                    variant="outline"
+                    className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter === "inactive"
+                      ? "bg-gray-500 text-white font-semibold shadow-sm scale-105"
+                      : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                      }`}
+                  >
+                    {t("clients.stats.inactive")} ({statusCounts?.inactive ?? 0})
+                  </Badge>
+                </div>
+              )}
+              {showCreateButton && (
+                <Button onClick={() => setCreateDialog(true)}>
+                  <Plus className="h-4 w-4 mr-0 md:mr-2" />
+                  <span className="hidden md:inline-flex">{t("paymentMethods.list.add")}</span>
+                </Button>
+              )}
+            </div>
           </CardHeader>
 
           <CardContent className="p-0">

--- a/frontend/src/pages/(app)/payment-methods/index.tsx
+++ b/frontend/src/pages/(app)/payment-methods/index.tsx
@@ -1,10 +1,9 @@
-import { Banknote, Plus, Search } from "lucide-react"
-import { Card, CardContent } from "@/components/ui/card"
+import { Banknote, Plus } from "lucide-react"
 import { PaymentMethodsList, type PaymentMethodsListHandle } from "@/pages/(app)/payment-methods/_components/payment-method-list"
 import { useRef, useState } from "react"
 import { useSse } from "@/hooks/use-fetch"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
+import { usePageHeader } from "@/hooks/use-page-header"
 import { useTranslation } from "react-i18next"
 
 
@@ -19,6 +18,8 @@ export default function PaymentMethodsPage() {
     (pm.details || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
     (pm.type || "").toLowerCase().includes(searchTerm.toLowerCase()),
   )
+
+  usePageHeader(t("sidebar.navigation.paymentMethods"))
 
   const emptyState = (
     <div className="text-center py-12">
@@ -38,51 +39,13 @@ export default function PaymentMethodsPage() {
 
   return (
     <div className="max-w-7xl mx-auto space-y-6 p-6">
-      <div className="flex flex-col lg:flex-row items-start lg:items-center gap-4 lg:gap-0 lg:justify-between">
-        <div className="flex items-center space-x-3">
-          <div className="p-2 bg-blue-100 rounded-lg">
-            <Banknote className="h-5 w-5 text-blue-600" />
-          </div>
-          <div>
-            <div className="text-sm text-primary">{t("paymentMethods.description") || t("paymentMethods.title")}</div>
-            <div className="font-medium text-foreground">{`${filtered.length} ${t("paymentMethods.title")}`}</div>
-          </div>
-        </div>
-
-        <div className="flex flex-row items-center gap-4 w-full lg:w-fit lg:gap-6 lg:justify-between">
-          <div className="relative w-full lg:w-fit">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-            <Input placeholder={t("paymentMethods.search.placeholder") || ""} value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} className="pl-10 w-full" />
-          </div>
-          <Button onClick={() => pmListRef.current?.handleAddClick()}>
-            <Plus className="h-4 w-4 mr-0 md:mr-2" />
-            <span className="hidden md:inline-flex">{t("paymentMethods.list.add") || t("paymentMethods.add.title") || t("actions.add")}</span>
-          </Button>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-        <Card>
-          <CardContent>
-            <div className="flex items-center space-x-4">
-              <div className="p-3 bg-blue-100 rounded-lg">
-                <Banknote className="h-6 w-6 text-blue-600" />
-              </div>
-              <div>
-                <p className="text-2xl font-semibold text-foreground">{paymentMethods?.length || 0}</p>
-                <p className="text-sm text-primary">{t("paymentMethods.stats.total") || t("paymentMethods.title")}</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
 
       <PaymentMethodsList
         ref={pmListRef}
         paymentMethods={filtered}
         loading={false}
-        title={t("paymentMethods.title")}
-        description={t("paymentMethods.description")}
+        searchTerm={searchTerm}
+        onSearchChange={setSearchTerm}
         emptyState={emptyState}
         showCreateButton={true}
       />

--- a/frontend/src/pages/(app)/payment-methods/index.tsx
+++ b/frontend/src/pages/(app)/payment-methods/index.tsx
@@ -7,17 +7,28 @@ import { usePageHeader } from "@/hooks/use-page-header"
 import { useTranslation } from "react-i18next"
 
 
+type ActiveFilter = "active" | "inactive" | undefined
+
 export default function PaymentMethodsPage() {
   const { t } = useTranslation()
   const pmListRef = useRef<PaymentMethodsListHandle>(null)
   const [searchTerm, setSearchTerm] = useState("")
+  const [statusFilter, setStatusFilter] = useState<ActiveFilter>(undefined)
   const { data: paymentMethods = [] } = useSse<any[]>("/api/payment-methods/sse")
 
   const filtered = (paymentMethods || []).filter((pm) =>
-    (pm.name || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
-    (pm.details || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
-    (pm.type || "").toLowerCase().includes(searchTerm.toLowerCase()),
+    ((pm.name || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (pm.details || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (pm.type || "").toLowerCase().includes(searchTerm.toLowerCase())) &&
+    (!statusFilter ||
+      (statusFilter === "active" && pm.isActive) ||
+      (statusFilter === "inactive" && !pm.isActive)),
   )
+
+  const statusCounts = {
+    active: paymentMethods?.filter((pm) => pm.isActive).length || 0,
+    inactive: paymentMethods?.filter((pm) => !pm.isActive).length || 0,
+  }
 
   usePageHeader(t("sidebar.navigation.paymentMethods"))
 
@@ -46,6 +57,9 @@ export default function PaymentMethodsPage() {
         loading={false}
         searchTerm={searchTerm}
         onSearchChange={setSearchTerm}
+        statusFilter={statusFilter}
+        onStatusFilterChange={setStatusFilter}
+        statusCounts={statusCounts}
         emptyState={emptyState}
         showCreateButton={true}
       />

--- a/frontend/src/pages/(app)/quotes/_components/quote-list.tsx
+++ b/frontend/src/pages/(app)/quotes/_components/quote-list.tsx
@@ -24,9 +24,9 @@ interface QuoteListProps {
     description?: string
     searchTerm?: string
     onSearchChange?: (value: string) => void
-    statusFilter?: "all" | "draft" | "signed"
-    onStatusFilterChange?: (value: "all" | "draft" | "signed") => void
-    statusCounts?: { all: number; draft: number; signed: number }
+    statusFilter?: "draft" | "sent" | "signed"
+    onStatusFilterChange?: (value: "draft" | "sent" | "signed" | undefined) => void
+    statusCounts?: { draft: number; sent: number; signed: number }
     page?: number
     pageCount?: number
     setPage?: (page: number) => void
@@ -182,17 +182,7 @@ export const QuoteList = forwardRef<QuoteListHandle, QuoteListProps>(
                             {onStatusFilterChange && (
                                 <div className="flex items-center gap-2">
                                     <Badge
-                                        onClick={() => onStatusFilterChange("all")}
-                                        variant="outline"
-                                        className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all ${statusFilter === "all"
-                                            ? "border-transparent bg-gray-800 text-white font-semibold shadow-sm scale-105"
-                                            : "text-gray-500 hover:bg-gray-100"
-                                            }`}
-                                    >
-                                        {t("quotes.filters.all")} ({statusCounts?.all ?? 0})
-                                    </Badge>
-                                    <Badge
-                                        onClick={() => onStatusFilterChange("draft")}
+                                        onClick={() => onStatusFilterChange(statusFilter === "draft" ? undefined : "draft")}
                                         variant="outline"
                                         className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter === "draft"
                                             ? "bg-yellow-500 text-white font-semibold shadow-sm scale-105"
@@ -202,7 +192,17 @@ export const QuoteList = forwardRef<QuoteListHandle, QuoteListProps>(
                                         {t("quotes.filters.draft")} ({statusCounts?.draft ?? 0})
                                     </Badge>
                                     <Badge
-                                        onClick={() => onStatusFilterChange("signed")}
+                                        onClick={() => onStatusFilterChange(statusFilter === "sent" ? undefined : "sent")}
+                                        variant="outline"
+                                        className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter === "sent"
+                                            ? "bg-blue-600 text-white font-semibold shadow-sm scale-105"
+                                            : "bg-blue-50 text-blue-700/70 hover:bg-blue-100"
+                                            }`}
+                                    >
+                                        {t("quotes.filters.sent")} ({statusCounts?.sent ?? 0})
+                                    </Badge>
+                                    <Badge
+                                        onClick={() => onStatusFilterChange(statusFilter === "signed" ? undefined : "signed")}
                                         variant="outline"
                                         className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter === "signed"
                                             ? "bg-green-600 text-white font-semibold shadow-sm scale-105"

--- a/frontend/src/pages/(app)/quotes/_components/quote-list.tsx
+++ b/frontend/src/pages/(app)/quotes/_components/quote-list.tsx
@@ -1,10 +1,12 @@
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
-import { Download, Edit, Eye, FileText, Plus, Signature, Trash2 } from "lucide-react"
+import { Download, Edit, Eye, FileText, Plus, Search, Signature, Trash2 } from "lucide-react"
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react"
 import { useGetRaw, usePost } from "@/hooks/use-fetch"
 
 import BetterPagination from "../../../../components/pagination"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "../../../../components/ui/button"
+import { Input } from "@/components/ui/input"
 import type { Quote } from "@/types"
 import { QuoteDeleteDialog } from "@/pages/(app)/quotes/_components/quote-delete"
 import { QuotePdfModal } from "@/pages/(app)/quotes/_components/quote-pdf-view"
@@ -18,8 +20,13 @@ import { useTranslation } from "react-i18next"
 interface QuoteListProps {
     quotes: Quote[]
     loading: boolean
-    title: string
-    description: string
+    title?: string
+    description?: string
+    searchTerm?: string
+    onSearchChange?: (value: string) => void
+    statusFilter?: "all" | "draft" | "signed"
+    onStatusFilterChange?: (value: "all" | "draft" | "signed") => void
+    statusCounts?: { all: number; draft: number; signed: number }
     page?: number
     pageCount?: number
     setPage?: (page: number) => void
@@ -34,7 +41,7 @@ export interface QuoteListHandle {
 
 export const QuoteList = forwardRef<QuoteListHandle, QuoteListProps>(
     (
-        { quotes, loading, title, description, page, pageCount, setPage, mutate, emptyState, showCreateButton = false },
+        { quotes, loading, title, description, searchTerm, onSearchChange, statusFilter, onStatusFilterChange, statusCounts, page, pageCount, setPage, mutate, emptyState, showCreateButton = false },
         ref,
     ) => {
         const { t } = useTranslation()
@@ -152,20 +159,67 @@ export const QuoteList = forwardRef<QuoteListHandle, QuoteListProps>(
         return (
             <>
                 <Card className="gap-0">
-                    <CardHeader className="border-b flex flex-row items-center justify-between">
-                        <div>
-                            <CardTitle className="flex items-center space-x-2">
-                                <FileText className="h-5 w-5 " />
-                                <span>{title}</span>
-                            </CardTitle>
-                            <CardDescription>{description}</CardDescription>
+                    <CardHeader className="border-b flex flex-col sm:flex-row items-stretch sm:items-center gap-3 sm:justify-between">
+                        {title ? (
+                            <div>
+                                <CardTitle className="flex items-center space-x-2">
+                                    <span>{title}</span>
+                                </CardTitle>
+                                {description && <CardDescription>{description}</CardDescription>}
+                            </div>
+                        ) : onSearchChange ? (
+                            <div className="relative w-full sm:w-fit sm:flex-1 sm:max-w-sm">
+                                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+                                <Input
+                                    placeholder={t("quotes.search.placeholder")}
+                                    value={searchTerm}
+                                    onChange={(e) => onSearchChange(e.target.value)}
+                                    className="pl-10 w-full"
+                                />
+                            </div>
+                        ) : null}
+                        <div className="flex items-center gap-2 sm:ml-auto">
+                            {onStatusFilterChange && (
+                                <div className="flex items-center gap-2">
+                                    <Badge
+                                        onClick={() => onStatusFilterChange("all")}
+                                        variant="outline"
+                                        className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all ${statusFilter === "all"
+                                            ? "border-transparent bg-gray-800 text-white font-semibold shadow-sm scale-105"
+                                            : "text-gray-500 hover:bg-gray-100"
+                                            }`}
+                                    >
+                                        {t("quotes.filters.all")} ({statusCounts?.all ?? 0})
+                                    </Badge>
+                                    <Badge
+                                        onClick={() => onStatusFilterChange("draft")}
+                                        variant="outline"
+                                        className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter === "draft"
+                                            ? "bg-yellow-500 text-white font-semibold shadow-sm scale-105"
+                                            : "bg-yellow-50 text-yellow-700/70 hover:bg-yellow-100"
+                                            }`}
+                                    >
+                                        {t("quotes.filters.draft")} ({statusCounts?.draft ?? 0})
+                                    </Badge>
+                                    <Badge
+                                        onClick={() => onStatusFilterChange("signed")}
+                                        variant="outline"
+                                        className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter === "signed"
+                                            ? "bg-green-600 text-white font-semibold shadow-sm scale-105"
+                                            : "bg-green-50 text-green-700/70 hover:bg-green-100"
+                                            }`}
+                                    >
+                                        {t("quotes.filters.signed")} ({statusCounts?.signed ?? 0})
+                                    </Badge>
+                                </div>
+                            )}
+                            {showCreateButton && (
+                                <Button onClick={handleAddClick}>
+                                    <Plus className="h-4 w-4 mr-0 md:mr-2" />
+                                    <span className="hidden md:inline-flex">{t("quotes.list.actions.addNew")}</span>
+                                </Button>
+                            )}
                         </div>
-                        {showCreateButton && (
-                            <Button onClick={handleAddClick}>
-                                <Plus className="h-4 w-4 mr-0 md:mr-2" />
-                                <span className="hidden md:inline-flex">{t("quotes.list.actions.addNew")}</span>
-                            </Button>
-                        )}
                     </CardHeader>
 
                     <CardContent className="p-0">

--- a/frontend/src/pages/(app)/quotes/_components/quote-upsert.tsx
+++ b/frontend/src/pages/(app)/quotes/_components/quote-upsert.tsx
@@ -194,12 +194,16 @@ export function QuoteUpsert({ quote, open, onOpenChange }: QuoteUpsertDialogProp
     return (
         <>
             <Dialog open={open} onOpenChange={onOpenChange}>
-                <DialogContent className="max-w-sm lg:max-w-4xl" dataCy="quote-dialog">
-                    <DialogHeader>
+                <DialogContent
+                    className="max-w-sm lg:max-w-4xl h-[85dvh] max-h-[85dvh] p-0 gap-0 flex flex-col overflow-hidden"
+                    dataCy="quote-dialog"
+                >
+                    <DialogHeader className="shrink-0 border-b px-6 py-4">
                         <DialogTitle>{t(`quotes.upsert.title.${isEdit ? "edit" : "create"}`)}</DialogTitle>
                     </DialogHeader>
+                    <div className="flex-1 overflow-y-auto px-6 py-4">
                     <Form {...form}>
-                        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" data-cy="quote-form">
+                        <form id="quote-form" onSubmit={handleSubmit(onSubmit)} className="space-y-4" data-cy="quote-form">
                             <FormField
                                 control={control}
                                 name="title"
@@ -510,17 +514,18 @@ export function QuoteUpsert({ quote, open, onOpenChange }: QuoteUpsertDialogProp
                                     {t("quotes.upsert.form.items.addItem")}
                                 </Button>
                             </FormItem>
-
-                            <div className="flex justify-end space-x-2">
-                                <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                                    {t("quotes.upsert.actions.cancel")}
-                                </Button>
-                                <Button type="submit" dataCy="quote-submit">
-                                    {t(`quotes.upsert.actions.${isEdit ? "save" : "create"}`)}
-                                </Button>
-                            </div>
                         </form>
                     </Form>
+                    </div>
+
+                    <div className="shrink-0 border-t px-6 py-4 flex justify-end space-x-2">
+                        <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                            {t("quotes.upsert.actions.cancel")}
+                        </Button>
+                        <Button type="submit" form="quote-form" dataCy="quote-submit">
+                            {t(`quotes.upsert.actions.${isEdit ? "save" : "create"}`)}
+                        </Button>
+                    </div>
                 </DialogContent>
             </Dialog>
 

--- a/frontend/src/pages/(app)/quotes/index.tsx
+++ b/frontend/src/pages/(app)/quotes/index.tsx
@@ -9,7 +9,7 @@ import type { QuoteListHandle } from "@/pages/(app)/quotes/_components/quote-lis
 import { usePageHeader } from "@/hooks/use-page-header"
 import { useTranslation } from "react-i18next"
 
-type QuoteStatusFilter = "all" | "draft" | "signed"
+type QuoteStatusFilter = "draft" | "sent" | "signed" | undefined
 
 export default function Quotes() {
     const { t } = useTranslation()
@@ -37,21 +37,24 @@ export default function Quotes() {
     }, [downloadQuotePdf, pdf])
 
     const [searchTerm, setSearchTerm] = useState("")
-    const [statusFilter, setStatusFilter] = useState<QuoteStatusFilter>("all")
+    const [statusFilter, setStatusFilter] = useState<QuoteStatusFilter>(undefined)
 
     const filteredQuotes =
         quotes?.quotes.filter(
             (quote) =>
                 (quote.title?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                    quote.status.toLowerCase().includes(searchTerm.toLowerCase())) &&
-                (statusFilter === "all" ||
+                    quote.rawNumber?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                    quote.number?.toString().includes(searchTerm) ||
+                    quote.client?.name?.toLowerCase().includes(searchTerm.toLowerCase())) &&
+                (!statusFilter ||
                     (statusFilter === "draft" && quote.status === "DRAFT") ||
+                    (statusFilter === "sent" && quote.status === "SENT") ||
                     (statusFilter === "signed" && quote.status === "SIGNED")),
         ) || []
 
     const quoteStatusCounts = {
-        all: quotes?.quotes.length || 0,
         draft: quotes?.quotes.filter((q) => q.status === "DRAFT").length || 0,
+        sent: quotes?.quotes.filter((q) => q.status === "SENT").length || 0,
         signed: quotes?.quotes.filter((q) => q.status === "SIGNED").length || 0,
     }
 

--- a/frontend/src/pages/(app)/quotes/index.tsx
+++ b/frontend/src/pages/(app)/quotes/index.tsx
@@ -1,14 +1,15 @@
-import { Card, CardContent } from "@/components/ui/card"
-import { FileText, Plus, Search } from "lucide-react"
+import { FileText, Plus } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { useGetRaw, useSse } from "@/hooks/use-fetch"
 
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import type { Quote } from "@/types"
 import { QuoteList } from "@/pages/(app)/quotes/_components/quote-list"
 import type { QuoteListHandle } from "@/pages/(app)/quotes/_components/quote-list"
+import { usePageHeader } from "@/hooks/use-page-header"
 import { useTranslation } from "react-i18next"
+
+type QuoteStatusFilter = "all" | "draft" | "signed"
 
 export default function Quotes() {
     const { t } = useTranslation()
@@ -36,13 +37,25 @@ export default function Quotes() {
     }, [downloadQuotePdf, pdf])
 
     const [searchTerm, setSearchTerm] = useState("")
+    const [statusFilter, setStatusFilter] = useState<QuoteStatusFilter>("all")
 
     const filteredQuotes =
         quotes?.quotes.filter(
             (quote) =>
-                quote.title?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                quote.status.toLowerCase().includes(searchTerm.toLowerCase()),
+                (quote.title?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                    quote.status.toLowerCase().includes(searchTerm.toLowerCase())) &&
+                (statusFilter === "all" ||
+                    (statusFilter === "draft" && quote.status === "DRAFT") ||
+                    (statusFilter === "signed" && quote.status === "SIGNED")),
         ) || []
+
+    const quoteStatusCounts = {
+        all: quotes?.quotes.length || 0,
+        draft: quotes?.quotes.filter((q) => q.status === "DRAFT").length || 0,
+        signed: quotes?.quotes.filter((q) => q.status === "SIGNED").length || 0,
+    }
+
+    usePageHeader(t("sidebar.navigation.quotes"))
 
     const emptyState = (
         <div className="text-center py-12">
@@ -66,97 +79,15 @@ export default function Quotes() {
 
     return (
         <div className="max-w-7xl mx-auto space-y-6 p-6">
-            <div className="flex flex-col lg:flex-row items-start lg:items-center gap-4 lg:gap-0 lg:justify-between">
-                <div className="flex items-center space-x-3">
-                    <div className="p-2 bg-blue-100 rounded-lg">
-                        <FileText className="h-5 w-5 text-blue-600" />
-                    </div>
-                    <div>
-                        <div className="text-sm text-primary">{t("quotes.header.subtitle")}</div>
-                        <div className="font-medium text-foreground">
-                            {t("quotes.header.count", {
-                                count: filteredQuotes.length,
-                                found: searchTerm ? t("quotes.header.found") : "",
-                            })}
-                        </div>
-                    </div>
-                </div>
-
-                <div className="flex flex-row items-center gap-4 w-full lg:w-fit lg:gap-6 lg:justify-between">
-                    <div className="relative w-full lg:w-fit">
-                        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-                        <Input
-                            placeholder={t("quotes.search.placeholder")}
-                            value={searchTerm}
-                            onChange={(e) => setSearchTerm(e.target.value)}
-                            className="pl-10 w-full"
-                        />
-                    </div>
-                    <Button onClick={() => quoteListRef.current?.handleAddClick()}>
-                        <Plus className="h-4 w-4 mr-0 md:mr-2" />
-                        <span className="hidden md:inline-flex">{t("quotes.actions.addNew")}</span>
-                    </Button>
-                </div>
-            </div>
-
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-                <Card>
-                    <CardContent>
-                        <div className="flex items-center space-x-4">
-                            <div className="p-3 bg-blue-100 rounded-lg">
-                                <FileText className="h-6 w-6 text-blue-600" />
-                            </div>
-                            <div>
-                                <p className="text-2xl font-semibold text-foreground">{quotes?.quotes.length || 0}</p>
-                                <p className="text-sm text-primary">{t("quotes.stats.total")}</p>
-                            </div>
-                        </div>
-                    </CardContent>
-                </Card>
-
-                <Card>
-                    <CardContent>
-                        <div className="flex items-center space-x-4">
-                            <div className="p-3 bg-yellow-100 rounded-lg">
-                                <div className="w-6 h-6 flex items-center justify-center">
-                                    <div className="w-3 h-3 bg-yellow-500 rounded-full"></div>
-                                </div>
-                            </div>
-                            <div>
-                                <p className="text-2xl font-semibold text-foreground">
-                                    {quotes?.quotes.filter((c) => c.status === "DRAFT").length || 0}
-                                </p>
-                                <p className="text-sm text-primary">{t("quotes.stats.draft")}</p>
-                            </div>
-                        </div>
-                    </CardContent>
-                </Card>
-
-                <Card>
-                    <CardContent>
-                        <div className="flex items-center space-x-4">
-                            <div className="p-3 bg-blue-100 rounded-lg">
-                                <div className="w-6 h-6 flex items-center justify-center">
-                                    <div className="w-3 h-3 bg-blue-500 rounded-full"></div>
-                                </div>
-                            </div>
-                            <div>
-                                <p className="text-2xl font-semibold text-foreground">
-                                    {quotes?.quotes.filter((c) => c.status === "SIGNED").length || 0}
-                                </p>
-                                <p className="text-sm text-primary">{t("quotes.stats.signed")}</p>
-                            </div>
-                        </div>
-                    </CardContent>
-                </Card>
-            </div>
-
             <QuoteList
                 ref={quoteListRef}
                 quotes={filteredQuotes}
                 loading={false}
-                title={t("quotes.list.title")}
-                description={t("quotes.list.description")}
+                searchTerm={searchTerm}
+                onSearchChange={setSearchTerm}
+                statusFilter={statusFilter}
+                onStatusFilterChange={setStatusFilter}
+                statusCounts={quoteStatusCounts}
                 page={page}
                 pageCount={quotes?.pageCount || 1}
                 setPage={setPage}

--- a/frontend/src/pages/(app)/receipts/_components/receipt-list.tsx
+++ b/frontend/src/pages/(app)/receipts/_components/receipt-list.tsx
@@ -1,10 +1,11 @@
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
-import { Download, Edit, Mail, Plus, Receipt as ReceiptIcon, Trash2 } from "lucide-react"
+import { Download, Edit, Mail, Plus, Receipt as ReceiptIcon, Search, Trash2 } from "lucide-react"
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react"
 import { useGetRaw, usePost } from "@/hooks/use-fetch"
 
 import BetterPagination from "../../../../components/pagination"
 import { Button } from "../../../../components/ui/button"
+import { Input } from "@/components/ui/input"
 import type React from "react"
 import type { Receipt } from "@/types"
 import { ReceiptDeleteDialog } from "@/pages/(app)/receipts/_components/receipt-delete"
@@ -16,8 +17,10 @@ import { useTranslation } from "react-i18next"
 interface ReceiptListProps {
     receipts: Receipt[]
     loading: boolean
-    title: string
-    description: string
+    title?: string
+    description?: string
+    searchTerm?: string
+    onSearchChange?: (value: string) => void
     page?: number
     pageCount?: number
     setPage?: (page: number) => void
@@ -32,7 +35,7 @@ export interface ReceiptListHandle {
 
 export const ReceiptList = forwardRef<ReceiptListHandle, ReceiptListProps>(
     (
-        { receipts, loading, title, description, page, pageCount, setPage, mutate, emptyState, showCreateButton = false },
+        { receipts, loading, title, description, searchTerm, onSearchChange, page, pageCount, setPage, mutate, emptyState, showCreateButton = false },
         ref,
     ) => {
         const { t } = useTranslation()
@@ -111,14 +114,25 @@ export const ReceiptList = forwardRef<ReceiptListHandle, ReceiptListProps>(
         return (
             <>
                 <Card className="gap-0">
-                    <CardHeader className="border-b flex flex-row items-center justify-between">
-                        <div>
-                            <CardTitle className="flex items-center space-x-2">
-                                <ReceiptIcon className="h-5 w-5 " />
-                                <span>{title}</span>
-                            </CardTitle>
-                            <CardDescription>{description}</CardDescription>
-                        </div>
+                    <CardHeader className="border-b flex flex-col sm:flex-row items-stretch sm:items-center gap-3 sm:justify-between">
+                        {title ? (
+                            <div>
+                                <CardTitle className="flex items-center space-x-2">
+                                    <span>{title}</span>
+                                </CardTitle>
+                                {description && <CardDescription>{description}</CardDescription>}
+                            </div>
+                        ) : onSearchChange ? (
+                            <div className="relative w-full sm:w-fit sm:flex-1 sm:max-w-sm">
+                                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+                                <Input
+                                    placeholder={t("receipts.search.placeholder")}
+                                    value={searchTerm}
+                                    onChange={(e) => onSearchChange(e.target.value)}
+                                    className="pl-10 w-full"
+                                />
+                            </div>
+                        ) : null}
                         {showCreateButton && (
                             <Button onClick={handleAddClick}>
                                 <Plus className="h-4 w-4 mr-0 md:mr-2" />

--- a/frontend/src/pages/(app)/receipts/index.tsx
+++ b/frontend/src/pages/(app)/receipts/index.tsx
@@ -1,11 +1,10 @@
-import { Card, CardContent } from "@/components/ui/card"
-import { Plus, Receipt as ReceiptIcon, Search } from "lucide-react"
+import { Plus, Receipt as ReceiptIcon } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { useGetRaw, useSse } from "@/hooks/use-fetch"
 
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import type { Receipt } from "@/types"
+import { usePageHeader } from "@/hooks/use-page-header"
 import { useTranslation } from "react-i18next"
 import { ReceiptList, type ReceiptListHandle } from "./_components/receipt-list"
 
@@ -47,6 +46,8 @@ export default function Receipts() {
                 receipt.invoice?.number?.toString().includes(searchTerm)
         ) || []
 
+    usePageHeader(t("sidebar.navigation.receipts"))
+
     const emptyState = (
         <div className="text-center py-12">
             <ReceiptIcon className="mx-auto h-12 w-12 text-gray-400" />
@@ -69,61 +70,13 @@ export default function Receipts() {
 
     return (
         <div className="max-w-7xl mx-auto space-y-6 p-6">
-            <div className="flex flex-col lg:flex-row items-start lg:items-center gap-4 lg:gap-0 lg:justify-between">
-                <div className="flex items-center space-x-3">
-                    <div className="p-2 bg-blue-100 rounded-lg">
-                        <ReceiptIcon className="h-5 w-5 text-blue-600" />
-                    </div>
-                    <div>
-                        <div className="text-sm text-primary">{t("receipts.header.subtitle")}</div>
-                        <div className="font-medium text-foreground">
-                            {t("receipts.header.count", {
-                                count: filteredReceipts.length,
-                                found: searchTerm ? t("receipts.header.found") : "",
-                            })}
-                        </div>
-                    </div>
-                </div>
-
-                <div className="flex flex-row items-center gap-4 w-full lg:w-fit lg:gap-6 lg:justify-between">
-                    <div className="relative w-full lg:w-fit">
-                        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-                        <Input
-                            placeholder={t("receipts.search.placeholder")}
-                            value={searchTerm}
-                            onChange={(e) => setSearchTerm(e.target.value)}
-                            className="pl-10 w-full"
-                        />
-                    </div>
-                    <Button onClick={() => receiptListRef.current?.handleAddClick()}>
-                        <Plus className="h-4 w-4 mr-0 md:mr-2" />
-                        <span className="hidden md:inline-flex">{t("receipts.actions.addNew")}</span>
-                    </Button>
-                </div>
-            </div>
-
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-                <Card>
-                    <CardContent>
-                        <div className="flex items-center space-x-4">
-                            <div className="p-3 bg-blue-100 rounded-lg">
-                                <ReceiptIcon className="h-6 w-6 text-blue-600" />
-                            </div>
-                            <div>
-                                <p className="text-2xl font-semibold text-foreground">{receipts?.receipts.length || 0}</p>
-                                <p className="text-sm text-primary">{t("receipts.stats.total")}</p>
-                            </div>
-                        </div>
-                    </CardContent>
-                </Card>
-            </div>
 
             <ReceiptList
                 ref={receiptListRef}
                 receipts={filteredReceipts}
                 loading={false}
-                title={t("receipts.list.title")}
-                description={t("receipts.list.description")}
+                searchTerm={searchTerm}
+                onSearchChange={setSearchTerm}
                 page={page}
                 pageCount={receipts?.pageCount || 1}
                 setPage={setPage}

--- a/frontend/src/pages/(app)/settings/-[tab].tsx
+++ b/frontend/src/pages/(app)/settings/-[tab].tsx
@@ -77,10 +77,7 @@ export default function Settings() {
 
     const currentMenuItem = menuItems.find((item) => item.value === currentTab)
 
-    usePageHeader(
-        currentMenuItem?.label ?? t("settings.title"),
-        currentMenuItem?.icon ? <currentMenuItem.icon className="h-5 w-5 text-blue-600" /> : null,
-    )
+    usePageHeader(t("settings.title"))
 
     const renderContent = () => {
         switch (currentTab) {

--- a/frontend/src/pages/(app)/settings/-[tab].tsx
+++ b/frontend/src/pages/(app)/settings/-[tab].tsx
@@ -11,6 +11,7 @@ import PDFTemplatesSettings from "./_components/pdf.settings"
 import PluginsSettings from "./_components/plugins.settings"
 import WebhooksSettings from "./_components/webhooks.settings"
 import { cn } from "@/lib/utils"
+import { usePageHeader } from "@/hooks/use-page-header"
 import { useTranslation } from "react-i18next"
 import { LogsSettings } from "./_components/logs.settings"
 
@@ -76,6 +77,11 @@ export default function Settings() {
 
     const currentMenuItem = menuItems.find((item) => item.value === currentTab)
 
+    usePageHeader(
+        currentMenuItem?.label ?? t("settings.title"),
+        currentMenuItem?.icon ? <currentMenuItem.icon className="h-5 w-5 text-blue-600" /> : null,
+    )
+
     const renderContent = () => {
         switch (currentTab) {
             case "company":
@@ -127,10 +133,7 @@ export default function Settings() {
             </div>
 
             <aside className="hidden lg:flex flex-col w-64 shrink-0 border-r bg-muted/30">
-                <div className="p-6">
-                    <h2 className="text-lg font-semibold">{t("settings.title") || "Settings"}</h2>
-                </div>
-                <nav className="flex-1 px-3 pb-6">
+                <nav className="flex-1 px-3 pb-6 pt-6">
                     <ul className="space-y-1">
                         {menuItems.map((item) => (
                             <li key={item.value}>

--- a/frontend/src/pages/(app)/signature/[id].tsx
+++ b/frontend/src/pages/(app)/signature/[id].tsx
@@ -10,7 +10,6 @@ import { Label } from "@/components/ui/label"
 import type { Quote } from "@/types"
 import type React from "react"
 import { toast } from "sonner"
-import { usePageHeader } from "@/hooks/use-page-header"
 import { useParams } from "react-router"
 
 interface Signature {
@@ -25,7 +24,6 @@ type SignatureState = "loading" | "ready" | "otp-sent" | "signing" | "signed" | 
 
 export default function Signature() {
     const { id } = useParams()
-    usePageHeader("Quote Signature", <FileText className="h-5 w-5 text-blue-600" />)
     const { data: signature, mutate } = useGet<Signature>(`/api/signatures/${id}`)
     const { data: pdfResponse } = useGetRaw<Response>(`/api/signatures/${id}/pdf`)
 
@@ -299,9 +297,12 @@ export default function Signature() {
 
     return (
         <div className="max-w-7xl mx-auto space-y-6 px-6 py-8">
-            <p className="text-muted-foreground">
-                Quote #{signature.quote.number} • Expires on {new Date(signature.expiresAt).toLocaleDateString()}
-            </p>
+            <div className="space-y-2">
+                <h1 className="text-3xl font-bold">Quote Signature</h1>
+                <p className="text-muted-foreground">
+                    Quote #{signature.quote.number} • Expires on {new Date(signature.expiresAt).toLocaleDateString()}
+                </p>
+            </div>
 
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
                 <div className="lg:col-span-2">

--- a/frontend/src/pages/(app)/signature/[id].tsx
+++ b/frontend/src/pages/(app)/signature/[id].tsx
@@ -10,6 +10,7 @@ import { Label } from "@/components/ui/label"
 import type { Quote } from "@/types"
 import type React from "react"
 import { toast } from "sonner"
+import { usePageHeader } from "@/hooks/use-page-header"
 import { useParams } from "react-router"
 
 interface Signature {
@@ -24,6 +25,7 @@ type SignatureState = "loading" | "ready" | "otp-sent" | "signing" | "signed" | 
 
 export default function Signature() {
     const { id } = useParams()
+    usePageHeader("Quote Signature", <FileText className="h-5 w-5 text-blue-600" />)
     const { data: signature, mutate } = useGet<Signature>(`/api/signatures/${id}`)
     const { data: pdfResponse } = useGetRaw<Response>(`/api/signatures/${id}/pdf`)
 
@@ -297,12 +299,9 @@ export default function Signature() {
 
     return (
         <div className="max-w-7xl mx-auto space-y-6 px-6 py-8">
-            <div className="space-y-2">
-                <h1 className="text-3xl font-bold">Quote Signature</h1>
-                <p className="text-muted-foreground">
-                    Quote #{signature.quote.number} • Expires on {new Date(signature.expiresAt).toLocaleDateString()}
-                </p>
-            </div>
+            <p className="text-muted-foreground">
+                Quote #{signature.quote.number} • Expires on {new Date(signature.expiresAt).toLocaleDateString()}
+            </p>
 
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
                 <div className="lg:col-span-2">

--- a/frontend/src/pages/(app)/stats.tsx
+++ b/frontend/src/pages/(app)/stats.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { CartesianGrid, Line, LineChart, XAxis } from "recharts";
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useEffect, useMemo, useState } from "react";
 
 import { TrendingUp } from "lucide-react";
@@ -9,6 +10,8 @@ import YearPicker from "@/components/year-picker";
 import { useGet } from "@/hooks/use-fetch";
 import { usePageHeader } from "@/hooks/use-page-header";
 import { useTranslation } from "react-i18next";
+
+type StatsTab = "monthly" | "yearly";
 
 type MonthStat = { month: number; invoiced: number; revenue: number; deposits: number };
 type YearStat = { year: number; invoiced: number; revenue: number; deposits: number };
@@ -21,6 +24,7 @@ export default function StatsPage() {
   const [year, setYear] = useState<number>(currentYear);
   const [startYear, setStartYear] = useState<number>(currentYear - 5);
   const [endYear, setEndYear] = useState<number>(currentYear);
+  const [activeTab, setActiveTab] = useState<StatsTab>("monthly");
 
   usePageHeader(t("stats.title"), <TrendingUp className="h-5 w-5 text-blue-600" />);
 
@@ -89,6 +93,14 @@ export default function StatsPage() {
     <div className="max-w-7xl mx-auto space-y-6 p-6">
       <p className="text-muted-foreground">{t("stats.description")}</p>
 
+      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as StatsTab)}>
+        <TabsList>
+          <TabsTrigger value="monthly">{t("stats.controls.tabs.monthly")}</TabsTrigger>
+          <TabsTrigger value="yearly">{t("stats.controls.tabs.yearly")}</TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      {activeTab === "monthly" && (
       <section className="space-y-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-2">
@@ -178,7 +190,9 @@ export default function StatsPage() {
           </CardContent>
         </Card>
       </section>
+      )}
 
+      {activeTab === "yearly" && (
       <section className="space-y-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-2">
@@ -273,6 +287,7 @@ export default function StatsPage() {
           </CardContent>
         </Card>
       </section>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/(app)/stats.tsx
+++ b/frontend/src/pages/(app)/stats.tsx
@@ -4,8 +4,10 @@ import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useEffect, useMemo, useState } from "react";
 
+import { TrendingUp } from "lucide-react";
 import YearPicker from "@/components/year-picker";
 import { useGet } from "@/hooks/use-fetch";
+import { usePageHeader } from "@/hooks/use-page-header";
 import { useTranslation } from "react-i18next";
 
 type MonthStat = { month: number; invoiced: number; revenue: number; deposits: number };
@@ -19,6 +21,8 @@ export default function StatsPage() {
   const [year, setYear] = useState<number>(currentYear);
   const [startYear, setStartYear] = useState<number>(currentYear - 5);
   const [endYear, setEndYear] = useState<number>(currentYear);
+
+  usePageHeader(t("stats.title"), <TrendingUp className="h-5 w-5 text-blue-600" />);
 
   const { data: monthlyData } = useGet<MonthlyResponse>(`/api/stats/monthly?year=${year}`);
   const { data: yearlyData } = useGet<YearlyResponse>(`/api/stats/yearly?start=${startYear}&end=${endYear}`);
@@ -83,12 +87,7 @@ export default function StatsPage() {
 
   return (
     <div className="max-w-7xl mx-auto space-y-6 p-6">
-      <div className="flex items-center space-x-3">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("stats.title")}</h1>
-          <p className="text-muted-foreground">{t("stats.description")}</p>
-        </div>
-      </div>
+      <p className="text-muted-foreground">{t("stats.description")}</p>
 
       <section className="space-y-4">
         <div className="flex items-center justify-between">

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,0 +1,37 @@
+import { AlertTriangle, RefreshCw } from "lucide-react"
+import { isRouteErrorResponse, useRouteError } from "react-router"
+
+import { Button } from "@/components/ui/button"
+import { useTranslation } from "react-i18next"
+
+export function Catch() {
+    const error = useRouteError()
+    const { t } = useTranslation()
+
+    const message = isRouteErrorResponse(error)
+        ? error.statusText || error.data
+        : error instanceof Error
+            ? error.message
+            : undefined
+
+    if (import.meta.env.DEV && error) {
+        console.error(error)
+    }
+
+    return (
+        <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-6 text-center">
+            <div className="rounded-full bg-red-100 p-3">
+                <AlertTriangle className="h-8 w-8 text-red-600" />
+            </div>
+            <div className="space-y-1">
+                <h1 className="text-xl font-semibold text-foreground">{t("errorBoundary.title")}</h1>
+                <p className="max-w-md text-sm text-muted-foreground">{t("errorBoundary.description")}</p>
+                {message ? <p className="max-w-md text-xs text-muted-foreground/70">{message}</p> : null}
+            </div>
+            <Button onClick={() => window.location.reload()}>
+                <RefreshCw className="h-4 w-4 mr-2" />
+                {t("errorBoundary.reload")}
+            </Button>
+        </div>
+    )
+}

--- a/frontend/src/types/invoice.ts
+++ b/frontend/src/types/invoice.ts
@@ -6,7 +6,8 @@ export enum InvoiceStatus {
     PAID = 'PAID',
     UNPAID = 'UNPAID',
     OVERDUE = 'OVERDUE',
-    SENT = 'SENT'
+    SENT = 'SENT',
+    UPCOMING = 'UPCOMING'
 }
 
 export enum InvoiceItemType {
@@ -34,6 +35,7 @@ export interface Invoice {
     rawNumber?: string; // Optional raw number for custom formats
     title?: string; // Optional title from DTOs
     quoteId?: string;
+    recurringInvoiceId?: string;
     clientId: string;
     companyId: string;
     client: Client

--- a/nginx.conf
+++ b/nginx.conf
@@ -12,5 +12,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_set_header X-Accel-Buffering no;
     }
 }


### PR DESCRIPTION
Closes #302 

- Single create button + in-table search on quotes/invoices/receipts/clients/payment-methods
- Replace stat cards with status filter badges (with live counts)
- Recurring invoices: filter tab + "upcoming" preview row in invoice list
- Fixed-size invoice/quote upsert modals with sticky header/footer
- Invoice creation modal: tabs to switch between one-time and recurring invoice
- Settings header always shows "Paramètres"/"Settings" regardless of active tab
- Sidebar company button now links to /settings/company
- Stats page: separate "By month"/"By year" tabs
- Fix invoice/quote search to also match number, rawNumber, and client name
<img width="1391" height="816" alt="Capture d’écran 2026-06-21 à 21 18 47" src="https://github.com/user-attachments/assets/b059f200-5875-4d55-80ce-ab4138445254" />
<img width="1392" height="817" alt="Capture d’écran 2026-06-21 à 21 18 56" src="https://github.com/user-attachments/assets/f06ceda1-271b-43c4-bb56-f313509a3537" />
<img width="1392" height="817" alt="Capture d’écran 2026-06-21 à 21 19 05" src="https://github.com/user-attachments/assets/f794bde6-71c0-4b92-a444-29a40e53abdf" />
<img width="1392" height="818" alt="Capture d’écran 2026-06-21 à 21 19 13" src="https://github.com/user-attachments/assets/9cb4cf91-64d9-4e0e-af7f-6c702d28dbe9" />
<img width="1390" height="813" alt="Capture d’écran 2026-06-21 à 21 19 25" src="https://github.com/user-attachments/assets/5d64c45d-d232-4a17-9701-3a72fa720d6f" />
<img width="1391" height="817" alt="Capture d’écran 2026-06-21 à 21 19 33" src="https://github.com/user-attachments/assets/d4d495a1-e0f5-4497-bf4d-2555b88f7bc5" />
<img width="1395" height="818" alt="Capture d’écran 2026-06-21 à 21 19 42" src="https://github.com/user-attachments/assets/9e98db54-91e6-4c72-b504-cf0b1098532c" />
