### PR TITLE
refactor(payments): rename receipt domain to payment (DB, enums, i18n)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The project is still open, and I can continue to review and manage community pul
 - Track status of quotes and invoices (signed, paid, unread, etc.)  
 - Built-in quote signing system with secure tokens  
 - Generate and send quote/invoice emails directly from the app
-- Generate clean PDF documents (quotes, invoices, receipts, and more)  
+- Generate clean PDF documents (quotes, invoices, payments, and more)  
 - Custom brand identity: logo, company name, VAT, and more  
 - Authentication via JWT or OIDC (stored in cookies)
 - International-friendly: Default English UI, customizable currencies  

--- a/backend/prisma/migrations/20260624130000_rename_receipt_to_payment/migration.sql
+++ b/backend/prisma/migrations/20260624130000_rename_receipt_to_payment/migration.sql
@@ -1,0 +1,50 @@
+/*
+  Renaming the Receipt domain to Payment as part of the receipt -> payment refactor.
+
+  - Renamed table "Receipt" to "Payment"
+  - Renamed table "ReceiptItem" to "PaymentItem"
+  - Renamed column "ReceiptItem"."receiptId" to "PaymentItem"."paymentId"
+  - Renamed column "PDFConfig"."receipt" to "PDFConfig"."payment"
+  - Renamed primary keys / foreign keys to match Prisma naming conventions
+  - Added new PAYMENT_* values to the "WebhookEvent" enum (old RECEIPT_* kept, deprecated)
+  - Added PAYMENT value to the "MailTemplateType" enum (old RECEIPT kept, deprecated)
+
+  Existing data is preserved; the MailTemplate rows are migrated to the new enum
+  value in a separate migration (a freshly added enum value cannot be used in the
+  same transaction that adds it).
+*/
+
+-- Rename tables
+ALTER TABLE "Receipt" RENAME TO "Payment";
+ALTER TABLE "ReceiptItem" RENAME TO "PaymentItem";
+
+-- Rename foreign key column
+ALTER TABLE "PaymentItem" RENAME COLUMN "receiptId" TO "paymentId";
+
+-- Rename constraints to follow Prisma "<Table>_<col>_fkey" / "<Table>_pkey" convention
+ALTER TABLE "Payment" RENAME CONSTRAINT "Receipt_pkey" TO "Payment_pkey";
+ALTER TABLE "Payment" RENAME CONSTRAINT "Receipt_invoiceId_fkey" TO "Payment_invoiceId_fkey";
+ALTER TABLE "PaymentItem" RENAME CONSTRAINT "ReceiptItem_pkey" TO "PaymentItem_pkey";
+ALTER TABLE "PaymentItem" RENAME CONSTRAINT "ReceiptItem_invoiceItemId_fkey" TO "PaymentItem_invoiceItemId_fkey";
+ALTER TABLE "PaymentItem" RENAME CONSTRAINT "ReceiptItem_receiptId_fkey" TO "PaymentItem_paymentId_fkey";
+
+-- Rename the PDFConfig label column and migrate the untouched default value
+ALTER TABLE "PDFConfig" RENAME COLUMN "receipt" TO "payment";
+ALTER TABLE "PDFConfig" ALTER COLUMN "payment" SET DEFAULT 'Payment';
+UPDATE "PDFConfig" SET "payment" = 'Payment' WHERE "payment" = 'Receipt';
+
+-- Extend the MailTemplateType enum
+ALTER TYPE "MailTemplateType" ADD VALUE 'PAYMENT';
+
+-- Extend the WebhookEvent enum with the new payment document events
+ALTER TYPE "WebhookEvent" ADD VALUE 'PAYMENT_CREATED';
+ALTER TYPE "WebhookEvent" ADD VALUE 'PAYMENT_UPDATED';
+ALTER TYPE "WebhookEvent" ADD VALUE 'PAYMENT_DELETED';
+ALTER TYPE "WebhookEvent" ADD VALUE 'PAYMENT_SENT';
+ALTER TYPE "WebhookEvent" ADD VALUE 'PAYMENT_PDF_GENERATED';
+ALTER TYPE "WebhookEvent" ADD VALUE 'PAYMENT_CREATED_FROM_INVOICE';
+ALTER TYPE "WebhookEvent" ADD VALUE 'PAYMENT_SEARCHED';
+ALTER TYPE "WebhookEvent" ADD VALUE 'PAYMENT_ITEM_CREATED';
+ALTER TYPE "WebhookEvent" ADD VALUE 'PAYMENT_ITEM_UPDATED';
+ALTER TYPE "WebhookEvent" ADD VALUE 'PAYMENT_ITEM_DELETED';
+ALTER TYPE "WebhookEvent" ADD VALUE 'PAYMENT_NUMBER_GENERATED';

--- a/backend/prisma/migrations/20260624130100_migrate_receipt_mailtemplate_to_payment/migration.sql
+++ b/backend/prisma/migrations/20260624130100_migrate_receipt_mailtemplate_to_payment/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Migrate existing mail templates from the deprecated RECEIPT type to PAYMENT.
+
+  Run as a separate migration because the PAYMENT enum value was added in the
+  previous migration and Postgres forbids using a freshly added enum value in
+  the same transaction that introduced it.
+*/
+
+UPDATE "MailTemplate" SET "type" = 'PAYMENT' WHERE "type" = 'RECEIPT';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -188,6 +188,8 @@ enum MailTemplateType {
   SIGNATURE_REQUEST
   VERIFICATION_CODE
   INVOICE
+  PAYMENT
+  /// @deprecated use PAYMENT instead
   RECEIPT
 }
 
@@ -262,7 +264,7 @@ model PDFConfig {
 
   invoice        String @default("Invoice")
   quote          String @default("Quote")
-  receipt        String @default("Receipt")
+  payment        String @default("Payment")
   description    String @default("Description:")
   date           String @default("Date:")
   dueDate        String @default("Due date:")
@@ -456,7 +458,7 @@ model Invoice {
   totalTTC           Float
   currency           Currency
   isActive           Boolean           @default(true)
-  receipts           Receipt[]
+  payments           Payment[]
 }
 
 model InvoiceItem {
@@ -469,7 +471,7 @@ model InvoiceItem {
   vatRate      Float // 20 for 20%
   type         ItemType      @default(SERVICE)
   order        Int
-  receiptItems ReceiptItem[]
+  paymentItems PaymentItem[]
 }
 
 // Recurring invoice model
@@ -511,23 +513,23 @@ model RecurringInvoiceItem {
   order              Int
 }
 
-// Receipt models
-model ReceiptItem {
+// Payment models
+model PaymentItem {
   id            String      @id @default(uuid())
   invoiceItem   InvoiceItem @relation(fields: [invoiceItemId], references: [id])
   invoiceItemId String
   amountPaid    Float // Amount paid for this item
-  Receipt       Receipt     @relation(fields: [receiptId], references: [id])
-  receiptId     String
+  Payment       Payment     @relation(fields: [paymentId], references: [id])
+  paymentId     String
 }
 
-model Receipt {
+model Payment {
   id              String        @id @default(cuid())
   number          Int           @default(autoincrement())
   rawNumber       String? // Raw number for custom formats
   invoiceId       String
   invoice         Invoice       @relation(fields: [invoiceId], references: [id])
-  items           ReceiptItem[]
+  items           PaymentItem[]
   totalPaid       Float
   paymentMethod   String        @default("") // Ex: "Bank Transfer", "PayPal", "Cash"
   paymentDetails  String        @default("") // Details for the payment method (e.g., bank account number)
@@ -633,7 +635,16 @@ enum WebhookEvent {
   INVOICE_SEARCHED
   INVOICE_STATUS_CHANGED
 
-  // Receipt events
+  // Payment document events
+  PAYMENT_CREATED
+  PAYMENT_UPDATED
+  PAYMENT_DELETED
+  PAYMENT_SENT
+  PAYMENT_PDF_GENERATED
+  PAYMENT_CREATED_FROM_INVOICE
+  PAYMENT_SEARCHED
+
+  // Receipt events (deprecated, use PAYMENT_* instead)
   RECEIPT_CREATED
   RECEIPT_UPDATED
   RECEIPT_DELETED
@@ -642,7 +653,7 @@ enum WebhookEvent {
   RECEIPT_CREATED_FROM_INVOICE
   RECEIPT_SEARCHED
 
-  // Payment events
+  // Payment method events
   PAYMENT_RECEIVED
   PAYMENT_METHOD_CREATED
   PAYMENT_METHOD_UPDATED
@@ -747,7 +758,12 @@ enum WebhookEvent {
   INVOICE_ITEM_UPDATED
   INVOICE_ITEM_DELETED
 
-  // Receipt Item events
+  // Payment Item events
+  PAYMENT_ITEM_CREATED
+  PAYMENT_ITEM_UPDATED
+  PAYMENT_ITEM_DELETED
+
+  // Receipt Item events (deprecated, use PAYMENT_ITEM_* instead)
   RECEIPT_ITEM_CREATED
   RECEIPT_ITEM_UPDATED
   RECEIPT_ITEM_DELETED
@@ -765,6 +781,8 @@ enum WebhookEvent {
   // Number formatting events
   QUOTE_NUMBER_GENERATED
   INVOICE_NUMBER_GENERATED
+  PAYMENT_NUMBER_GENERATED
+  /// @deprecated use PAYMENT_NUMBER_GENERATED instead
   RECEIPT_NUMBER_GENERATED
 
   // Background process events

--- a/backend/src/modules/company/company.service.ts
+++ b/backend/src/modules/company/company.service.ts
@@ -81,12 +81,12 @@ export class CompanyService {
             }),
             prisma.mailTemplate.upsert({
                 where: {
-                    companyId_type: { companyId: company.id, type: MailTemplateType.RECEIPT }
+                    companyId_type: { companyId: company.id, type: MailTemplateType.PAYMENT }
                 },
                 create: {
-                    type: MailTemplateType.RECEIPT,
-                    subject: 'Receipt #{{RECEIPT_NUMBER}} from {{COMPANY_NAME}}',
-                    body: '<p>Dear {{CLIENT_NAME}},</p><p>Please find attached the receipt #{{RECEIPT_NUMBER}} from {{COMPANY_NAME}}.</p><p>Thank you for your business!</p><p>Best regards,<br>{{COMPANY_NAME}}</p><hr><p style="font-size: 12px; color: #666;">This email was sent from {{APP_URL}}</p>',
+                    type: MailTemplateType.PAYMENT,
+                    subject: 'Payment #{{PAYMENT_NUMBER}} from {{COMPANY_NAME}}',
+                    body: '<p>Dear {{CLIENT_NAME}},</p><p>Please find attached the payment receipt #{{PAYMENT_NUMBER}} from {{COMPANY_NAME}}.</p><p>Thank you for your business!</p><p>Best regards,<br>{{COMPANY_NAME}}</p><hr><p style="font-size: 12px; color: #666;">This email was sent from {{APP_URL}}</p>',
                     companyId: company.id
                 },
                 update: {}
@@ -124,8 +124,8 @@ export class CompanyService {
             secondaryColor: existingCompany.pdfConfig.secondaryColor,
 
             labels: {
-                // Receipt-specific labels
-                receipt: existingCompany.pdfConfig.receipt,
+                // Payment-specific labels
+                payment: existingCompany.pdfConfig.payment,
                 receivedFrom: existingCompany.pdfConfig.receivedFrom,
                 invoiceRefer: existingCompany.pdfConfig.invoiceRefer,
                 paymentDate: existingCompany.pdfConfig.paymentDate,
@@ -192,8 +192,8 @@ export class CompanyService {
                 primaryColor: pdfConfig.primaryColor,
                 secondaryColor: pdfConfig.secondaryColor,
 
-                // Receipt-specific labels
-                receipt: pdfConfig.labels.receipt,
+                // Payment-specific labels
+                payment: pdfConfig.labels.payment,
                 receivedFrom: pdfConfig.labels.receivedFrom,
                 invoiceRefer: pdfConfig.labels.invoiceRefer,
                 paymentDate: pdfConfig.labels.paymentDate,
@@ -360,8 +360,8 @@ export class CompanyService {
                     CLIENT_NAME: 'Acme',
                     COMPANY_NAME: existingCompany.name,
                 },
-                ...template.type === MailTemplateType.RECEIPT && {
-                    RECEIPT_NUMBER: 'REC-2025-0001',
+                ...template.type === MailTemplateType.PAYMENT && {
+                    PAYMENT_NUMBER: 'PAY-2025-0001',
                     CLIENT_NAME: 'Acme',
                     COMPANY_NAME: existingCompany.name,
                 }

--- a/backend/src/modules/company/dto/company.dto.ts
+++ b/backend/src/modules/company/dto/company.dto.ts
@@ -9,7 +9,7 @@ export interface PDFConfigDto {
     secondaryColor: string
     labels: {
         // Generic labels
-        receipt: string
+        payment: string
         billTo: string
         receivedFrom: string
         invoiceRefer: string

--- a/backend/src/modules/danger/danger.controller.ts
+++ b/backend/src/modules/danger/danger.controller.ts
@@ -25,7 +25,7 @@ export class DangerController {
   }
 
   @Post('reset/app')
-  @ApiOperation({ summary: 'Reset app data', description: 'Deletes all documents (invoices, quotes, receipts) while preserving company configuration.' })
+  @ApiOperation({ summary: 'Reset app data', description: 'Deletes all documents (invoices, quotes, payments) while preserving company configuration.' })
   @ApiQuery({ name: 'otp', required: true, type: String, description: 'One-time passcode sent via POST /danger/otp' })
   @ApiResponse({ status: 201, description: 'App data reset' })
   async resetApp(@User() user: CurrentUser, @Query('otp') otp: string) {

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -25,6 +25,27 @@ export class PaymentsService {
         this.logger = new Logger(PaymentsService.name);
     }
 
+    /**
+     * Dispatches a payment webhook event. The new PAYMENT_* event is emitted first,
+     * then the deprecated RECEIPT_* alias is emitted for backward compatibility with
+     * existing webhook subscriptions. The payload exposes both `payment` and the
+     * deprecated `receipt` key so old and new formatters keep working.
+     */
+    private async dispatchPaymentEvent(
+        current: WebhookEvent,
+        deprecated: WebhookEvent,
+        payload: { payment: any; invoice: any; client: any; company: any },
+    ) {
+        const fullPayload = { ...payload, receipt: payload.payment };
+        for (const event of [current, deprecated]) {
+            try {
+                await this.webhookDispatcher.dispatch(event, fullPayload);
+            } catch (error) {
+                this.logger.error(`Failed to dispatch ${event} webhook`, error);
+            }
+        }
+    }
+
     async getPayments(page: string) {
         const pageNumber = parseInt(page, 10) || 1;
         const pageSize = 10;
@@ -36,7 +57,7 @@ export class PaymentsService {
             throw new BadRequestException('No company found. Please create a company first.');
         }
 
-        const receipts = await prisma.receipt.findMany({
+        const payments = await prisma.payment.findMany({
             skip,
             take: pageSize,
             orderBy: {
@@ -54,9 +75,9 @@ export class PaymentsService {
             },
         });
 
-        const totalReceipts = await prisma.receipt.count();
+        const totalPayments = await prisma.payment.count();
 
-        const receiptsWithPM = await Promise.all(receipts.map(async (r: any) => {
+        const paymentsWithPM = await Promise.all(payments.map(async (r: any) => {
             if (r.paymentMethodId) {
                 const pm = await prisma.paymentMethod.findUnique({ where: { id: r.paymentMethodId } });
                 return { ...r, paymentMethod: pm ?? r.paymentMethod };
@@ -64,12 +85,12 @@ export class PaymentsService {
             return r;
         }));
 
-        return { pageCount: Math.ceil(totalReceipts / pageSize), payments: receiptsWithPM };
+        return { pageCount: Math.ceil(totalPayments / pageSize), payments: paymentsWithPM };
     }
 
     async searchPayments(query: string) {
         if (!query) {
-            const results = await prisma.receipt.findMany({
+            const results = await prisma.payment.findMany({
                 take: 10,
                 orderBy: {
                     number: 'asc',
@@ -96,7 +117,7 @@ export class PaymentsService {
             return resultsWithPM;
         }
 
-        const results = await prisma.receipt.findMany({
+        const results = await prisma.payment.findMany({
             where: {
                 OR: [
                     { invoice: { quote: { title: { contains: query } } } },
@@ -129,7 +150,7 @@ export class PaymentsService {
         return resultsWithPM;
     }
 
-    private async checkInvoiceAfterReceipt(invoiceId: string) {
+    private async checkInvoiceAfterPayment(invoiceId: string) {
         const invoice = await prisma.invoice.findUnique({
             where: { id: invoiceId }
         });
@@ -140,12 +161,12 @@ export class PaymentsService {
         }
 
         if (invoice.status !== 'PAID') {
-            const receipts = await prisma.receipt.findMany({
+            const payments = await prisma.payment.findMany({
                 where: { invoiceId },
                 select: { totalPaid: true },
             });
 
-            const totalPaid = receipts.reduce((sum, receipt) => sum + receipt.totalPaid, 0);
+            const totalPaid = payments.reduce((sum, payment) => sum + payment.totalPaid, 0);
             if (totalPaid >= invoice.totalTTC) {
                 await prisma.invoice.update({
                     where: { id: invoiceId },
@@ -175,7 +196,7 @@ export class PaymentsService {
             throw new BadRequestException('Invoice not found');
         }
 
-        const receipt = await prisma.receipt.create({
+        const payment = await prisma.payment.create({
             data: {
                 invoiceId: body.invoiceId,
                 items: {
@@ -194,22 +215,18 @@ export class PaymentsService {
             },
         });
 
-        await this.checkInvoiceAfterReceipt(invoice.id);
+        await this.checkInvoiceAfterPayment(invoice.id);
 
-        try {
-            await this.webhookDispatcher.dispatch(WebhookEvent.RECEIPT_CREATED, {
-                receipt,
-                invoice,
-                client: invoice.client,
-                company: invoice.company,
-            });
-        } catch (error) {
-            this.logger.error('Failed to dispatch RECEIPT_CREATED webhook', error);
-        }
+        await this.dispatchPaymentEvent(WebhookEvent.PAYMENT_CREATED, WebhookEvent.RECEIPT_CREATED, {
+            payment,
+            invoice,
+            client: invoice.client,
+            company: invoice.company,
+        });
 
-        logger.info('Payment created', { category: 'payment', details: { receiptId: receipt.id, companyId: invoice.company?.id } });
+        logger.info('Payment created', { category: 'payment', details: { paymentId: payment.id, companyId: invoice.company?.id } });
 
-        return receipt;
+        return payment;
     }
 
     async createPaymentFromInvoice(invoiceId: string) {
@@ -227,7 +244,7 @@ export class PaymentsService {
         }
 
         const discountFactor = 1 - clampDiscountRate(invoice.discountRate) / 100;
-        const newReceipt = await this.createPayment({
+        const newPayment = await this.createPayment({
             invoiceId: invoice.id,
             items: invoice.items.map(item => {
                 const vatMultiplier = 1 + (item.vatRate || 0) / 100;
@@ -243,40 +260,36 @@ export class PaymentsService {
             paymentDetails: invoice.paymentDetails || '',
         });
 
-        try {
-            await this.webhookDispatcher.dispatch(WebhookEvent.RECEIPT_CREATED_FROM_INVOICE, {
-                receipt: newReceipt,
-                invoice,
-                client: invoice.client,
-                company: invoice.company,
-            });
-        } catch (error) {
-            this.logger.error('Failed to dispatch RECEIPT_CREATED_FROM_INVOICE webhook', error);
-        }
+        await this.dispatchPaymentEvent(WebhookEvent.PAYMENT_CREATED_FROM_INVOICE, WebhookEvent.RECEIPT_CREATED_FROM_INVOICE, {
+            payment: newPayment,
+            invoice,
+            client: invoice.client,
+            company: invoice.company,
+        });
 
-        logger.info('Payment created from invoice', { category: 'payment', details: { receiptId: newReceipt.id, invoiceId } });
+        logger.info('Payment created from invoice', { category: 'payment', details: { paymentId: newPayment.id, invoiceId } });
 
-        return newReceipt;
+        return newPayment;
     }
 
     async editPayment(body: EditPaymentDto) {
-        const existingReceipt = await prisma.receipt.findUnique({
+        const existingPayment = await prisma.payment.findUnique({
             where: { id: body.id },
             include: {
                 items: true,
             },
         });
 
-        if (!existingReceipt) {
-            logger.error('Payment not found', { category: 'payment', details: { receiptId: body.id } });
+        if (!existingPayment) {
+            logger.error('Payment not found', { category: 'payment', details: { paymentId: body.id } });
             throw new BadRequestException('Payment not found');
         }
 
-        const updatedReceipt = await prisma.receipt.update({
-            where: { id: existingReceipt.id },
+        const updatedPayment = await prisma.payment.update({
+            where: { id: existingPayment.id },
             data: {
                 items: {
-                    deleteMany: { receiptId: existingReceipt.id },
+                    deleteMany: { paymentId: existingPayment.id },
                     createMany: {
                         data: body.items.map(item => ({
                             id: randomUUID(),
@@ -301,26 +314,22 @@ export class PaymentsService {
             },
         });
 
-        await this.checkInvoiceAfterReceipt(existingReceipt.invoiceId);
+        await this.checkInvoiceAfterPayment(existingPayment.invoiceId);
 
-        try {
-            await this.webhookDispatcher.dispatch(WebhookEvent.RECEIPT_UPDATED, {
-                receipt: updatedReceipt,
-                invoice: updatedReceipt.invoice,
-                client: updatedReceipt.invoice.client,
-                company: updatedReceipt.invoice.company,
-            });
-        } catch (error) {
-            this.logger.error('Failed to dispatch RECEIPT_UPDATED webhook', error);
-        }
+        await this.dispatchPaymentEvent(WebhookEvent.PAYMENT_UPDATED, WebhookEvent.RECEIPT_UPDATED, {
+            payment: updatedPayment,
+            invoice: updatedPayment.invoice,
+            client: updatedPayment.invoice.client,
+            company: updatedPayment.invoice.company,
+        });
 
-        logger.info('Payment updated', { category: 'payment', details: { receiptId: updatedReceipt.id } });
+        logger.info('Payment updated', { category: 'payment', details: { paymentId: updatedPayment.id } });
 
-        return updatedReceipt;
+        return updatedPayment;
     }
 
     async deletePayment(id: string) {
-        const existingReceipt = await prisma.receipt.findUnique({
+        const existingPayment = await prisma.payment.findUnique({
             where: { id },
             include: {
                 items: true,
@@ -333,39 +342,35 @@ export class PaymentsService {
             }
         });
 
-        if (!existingReceipt) {
-            logger.error('Payment not found', { category: 'payment', details: { receiptId: id } });
+        if (!existingPayment) {
+            logger.error('Payment not found', { category: 'payment', details: { paymentId: id } });
             throw new BadRequestException('Payment not found');
         }
 
-        await prisma.receiptItem.deleteMany({
-            where: { receiptId: id },
+        await prisma.paymentItem.deleteMany({
+            where: { paymentId: id },
         });
 
-        await prisma.receipt.delete({
+        await prisma.payment.delete({
             where: { id },
         });
 
-        await this.checkInvoiceAfterReceipt(existingReceipt.invoiceId);
+        await this.checkInvoiceAfterPayment(existingPayment.invoiceId);
 
-        try {
-            await this.webhookDispatcher.dispatch(WebhookEvent.RECEIPT_DELETED, {
-                receipt: existingReceipt,
-                invoice: existingReceipt.invoice,
-                client: existingReceipt.invoice.client,
-                company: existingReceipt.invoice.company,
-            });
-        } catch (error) {
-            this.logger.error('Failed to dispatch RECEIPT_DELETED webhook', error);
-        }
+        await this.dispatchPaymentEvent(WebhookEvent.PAYMENT_DELETED, WebhookEvent.RECEIPT_DELETED, {
+            payment: existingPayment,
+            invoice: existingPayment.invoice,
+            client: existingPayment.invoice.client,
+            company: existingPayment.invoice.company,
+        });
 
-        logger.info('Payment deleted', { category: 'payment', details: { receiptId: id } });
+        logger.info('Payment deleted', { category: 'payment', details: { paymentId: id } });
 
         return { message: 'Payment deleted successfully' };
     }
 
     async getPaymentPdf(paymentId: string): Promise<Uint8Array> {
-        const receipt = await prisma.receipt.findUnique({
+        const payment = await prisma.payment.findUnique({
             where: { id: paymentId },
             include: {
                 items: true,
@@ -381,16 +386,16 @@ export class PaymentsService {
             },
         });
 
-        if (!receipt) {
+        if (!payment) {
             logger.error('Payment not found', { category: 'payment', details: { paymentId } });
             throw new BadRequestException('Payment not found');
         }
 
-        const { pdfConfig } = receipt.invoice.company;
+        const { pdfConfig } = payment.invoice.company;
         const template = Handlebars.compile(baseTemplate);
 
-        if (receipt.invoice.client.name.length == 0) {
-            receipt.invoice.client.name = receipt.invoice.client.contactFirstname + " " + receipt.invoice.client.contactLastname
+        if (payment.invoice.client.name.length == 0) {
+            payment.invoice.client.name = payment.invoice.client.contactFirstname + " " + payment.invoice.client.contactLastname
         }
 
         const paymentMethodLabels: Record<string, string> = {
@@ -401,11 +406,11 @@ export class PaymentsService {
             OTHER: pdfConfig.paymentMethodOther,
         };
 
-        let paymentMethodName = receipt.paymentMethod;
-        let paymentDetails = receipt.paymentDetails;
+        let paymentMethodName = payment.paymentMethod;
+        let paymentDetails = payment.paymentDetails;
 
-        if (receipt.paymentMethodId) {
-            const pm = await prisma.paymentMethod.findUnique({ where: { id: receipt.paymentMethodId } });
+        if (payment.paymentMethodId) {
+            const pm = await prisma.paymentMethod.findUnique({ where: { id: payment.paymentMethodId } });
             if (pm) {
                 paymentMethodName = paymentMethodLabels[pm.type as string] || pm.type;
                 paymentDetails = pm.details || paymentDetails;
@@ -424,31 +429,31 @@ export class PaymentsService {
             PRODUCT: pdfConfig.product,
         };
 
-        const normalizedDiscountRate = clampDiscountRate(receipt.invoice.discountRate);
+        const normalizedDiscountRate = clampDiscountRate(payment.invoice.discountRate);
         const discountFactor = 1 - normalizedDiscountRate / 100;
-        let totalBeforeDiscount = receipt.totalPaid;
-        if (discountFactor > 0 && discountFactor < 1 && receipt.items.length > 0) {
-            totalBeforeDiscount = receipt.items.reduce((sum, item) => sum + (item.amountPaid / discountFactor), 0);
+        let totalBeforeDiscount = payment.totalPaid;
+        if (discountFactor > 0 && discountFactor < 1 && payment.items.length > 0) {
+            totalBeforeDiscount = payment.items.reduce((sum, item) => sum + (item.amountPaid / discountFactor), 0);
         }
-        const discountAmountValue = Math.max(0, totalBeforeDiscount - receipt.totalPaid);
+        const discountAmountValue = Math.max(0, totalBeforeDiscount - payment.totalPaid);
         const hasDiscount = normalizedDiscountRate > 0 && discountAmountValue > 0;
 
         const html = template({
-            number: receipt.rawNumber || receipt.number.toString(),
-            paymentDate: formatDate(receipt.invoice.company, new Date()),
-            invoiceNumber: receipt.invoice?.rawNumber || receipt.invoice?.number?.toString() || '',
-            client: receipt.invoice.client,
-            company: receipt.invoice.company,
-            currency: receipt.invoice.currency,
+            number: payment.rawNumber || payment.number.toString(),
+            paymentDate: formatDate(payment.invoice.company, new Date()),
+            invoiceNumber: payment.invoice?.rawNumber || payment.invoice?.number?.toString() || '',
+            client: payment.invoice.client,
+            company: payment.invoice.company,
+            currency: payment.invoice.currency,
             paymentMethod: paymentMethodName,
-            totalAmount: receipt.totalPaid.toFixed(2),
+            totalAmount: payment.totalPaid.toFixed(2),
             totalBeforeDiscount: totalBeforeDiscount.toFixed(2),
             discountAmount: discountAmountValue.toFixed(2),
             discountRate: Number(normalizedDiscountRate.toFixed(2)),
             hasDiscount,
 
-            items: receipt.items.map(item => {
-                const invoiceItem = receipt.invoice.items.find(i => i.id === item.invoiceItemId);
+            items: payment.items.map(item => {
+                const invoiceItem = payment.invoice.items.find(i => i.id === item.invoiceItemId);
                 return {
                     description: invoiceItem?.description || 'N/A',
                     type: itemTypeLabels[invoiceItem?.type as string] || invoiceItem?.type || '',
@@ -465,7 +470,7 @@ export class PaymentsService {
             padding: pdfConfig.padding ?? 40,
 
             labels: {
-                receipt: pdfConfig.receipt,
+                payment: pdfConfig.payment,
                 paymentDate: pdfConfig.paymentDate,
                 receivedFrom: pdfConfig.receivedFrom,
                 invoiceRefer: pdfConfig.invoiceRefer,
@@ -484,7 +489,7 @@ export class PaymentsService {
                 product: pdfConfig.product
             },
 
-            vatExemptText: receipt.invoice.company.exemptVat && (receipt.invoice.company.country || '').toUpperCase() === 'FRANCE' ? 'TVA non applicable, art. 293 B du CGI' : null,
+            vatExemptText: payment.invoice.company.exemptVat && (payment.invoice.company.country || '').toUpperCase() === 'FRANCE' ? 'TVA non applicable, art. 293 B du CGI' : null,
         });
 
         const pdfBuffer = await getPDF(html);
@@ -493,7 +498,7 @@ export class PaymentsService {
 
 
     async sendPaymentByEmail(id: string) {
-        const receipt = await prisma.receipt.findUnique({
+        const payment = await prisma.payment.findUnique({
             where: { id },
             include: {
                 invoice: {
@@ -505,7 +510,7 @@ export class PaymentsService {
             },
         });
 
-        if (!receipt || !receipt.invoice || !receipt.invoice.client) {
+        if (!payment || !payment.invoice || !payment.invoice.client) {
             logger.error('Payment or associated invoice/client not found', { category: 'payment', details: { id } });
             throw new BadRequestException('Payment or associated invoice/client not found');
         }
@@ -513,7 +518,7 @@ export class PaymentsService {
         const pdfBuffer = await this.getPaymentPdf(id);
 
         const mailTemplate = await prisma.mailTemplate.findFirst({
-            where: { type: 'RECEIPT' },
+            where: { type: 'PAYMENT' },
             select: { subject: true, body: true }
         });
 
@@ -522,24 +527,27 @@ export class PaymentsService {
             throw new BadRequestException('Email template for payment not found.');
         }
 
+        const paymentNumber = payment.rawNumber || payment.number.toString();
         const envVariables = {
             APP_URL: process.env.APP_URL,
-            RECEIPT_NUMBER: receipt.rawNumber || receipt.number.toString(),
-            COMPANY_NAME: receipt.invoice.company.name,
-            CLIENT_NAME: receipt.invoice.client.name,
+            PAYMENT_NUMBER: paymentNumber,
+            // Deprecated alias kept so legacy templates using {{RECEIPT_NUMBER}} keep working
+            RECEIPT_NUMBER: paymentNumber,
+            COMPANY_NAME: payment.invoice.company.name,
+            CLIENT_NAME: payment.invoice.client.name,
         };
 
-        if (!receipt.invoice.client.contactEmail) {
+        if (!payment.invoice.client.contactEmail) {
             logger.error('Client has no email configured; payment not sent', { category: 'payment', details: { id } });
             throw new BadRequestException('Client has no email configured; payment not sent');
         }
 
         const mailOptions = {
-            to: receipt.invoice.client.contactEmail,
+            to: payment.invoice.client.contactEmail,
             subject: mailTemplate.subject.replace(/{{(\w+)}}/g, (_, key) => envVariables[key] || ''),
             html: mailTemplate.body.replace(/{{(\w+)}}/g, (_, key) => envVariables[key] || ''),
             attachments: [{
-                filename: `payment-${receipt.rawNumber || receipt.number}.pdf`,
+                filename: `payment-${payment.rawNumber || payment.number}.pdf`,
                 content: pdfBuffer,
                 contentType: 'application/pdf',
             }],

--- a/backend/src/modules/payments/templates/base.template.ts
+++ b/backend/src/modules/payments/templates/base.template.ts
@@ -3,12 +3,12 @@ export const baseTemplate = `
 <html>
 <head>
   <meta charset="utf-8">
-  <title>{{labels.receipt}} {{number}}</title>
+  <title>{{labels.payment}} {{number}}</title>
   <style>
         body { font-family: {{fontFamily}}, sans-serif; margin: {{padding}}px; color: #333; }
         .header { display: flex; justify-content: space-between; margin-bottom: 40px; }
         .company-info h1 { margin: 0; color: {{primaryColor}}; }
-        .receipt-info { text-align: right; }
+        .payment-info { text-align: right; }
         .client-info { margin-bottom: 30px; }
         table { width: 100%; border-collapse: collapse; margin: 20px 0; }
         th, td { padding: 12px; text-align: left; border-bottom: 1px solid #ddd; }
@@ -33,9 +33,9 @@ export const baseTemplate = `
             {{#if company.legalId}}<strong>{{labels.legalId}}:</strong> {{company.legalId}}<br>{{/if}}
             {{#if company.VAT}}<strong>{{labels.VATId}}:</strong> {{company.VAT}}{{/if}}</p>
         </div>
-        <div class="receipt-info">
-            <h2>{{labels.receipt}}</h2>
-            <p><strong>{{labels.receipt}}:</strong> #{{number}}<br>
+        <div class="payment-info">
+            <h2>{{labels.payment}}</h2>
+            <p><strong>{{labels.payment}}:</strong> #{{number}}<br>
             <strong>{{labels.paymentDate}}</strong> {{paymentDate}}<br>
             <strong>{{labels.invoiceRefer}}</strong> #{{invoiceNumber}}</p>
         </div>

--- a/backend/src/modules/stats/stats.service.ts
+++ b/backend/src/modules/stats/stats.service.ts
@@ -26,10 +26,10 @@ export class StatsService {
                     lte: endOfYear,
                 },
             },
-            include: { receipts: true },
+            include: { payments: true },
         });
 
-        const receiptsInYear = await prisma.receipt.findMany({
+        const paymentsInYear = await prisma.payment.findMany({
             where: {
                 createdAt: {
                     gte: startOfYear,
@@ -42,16 +42,16 @@ export class StatsService {
             },
         });
 
-        const invoicesWithReceipts = await prisma.invoice.findMany({
-            where: { isActive: true, receipts: { some: {} } },
-            include: { receipts: { orderBy: { createdAt: 'asc' } } },
+        const invoicesWithPayments = await prisma.invoice.findMany({
+            where: { isActive: true, payments: { some: {} } },
+            include: { payments: { orderBy: { createdAt: 'asc' } } },
         });
 
         // Determine the payment moment for invoices that became fully paid
         const paidInvoices: { invoice: any; paidDate: Date }[] = [];
-        for (const inv of invoicesWithReceipts) {
+        for (const inv of invoicesWithPayments) {
             let cumulative = 0;
-            for (const r of inv.receipts) {
+            for (const r of inv.payments) {
                 cumulative += r.totalPaid;
                 if (cumulative >= inv.totalTTC) {
                     paidInvoices.push({ invoice: inv, paidDate: r.createdAt });
@@ -84,9 +84,9 @@ export class StatsService {
             m.invoiced += inv.totalTTC;
         }
 
-        // Revenue (without VAT) - calculated from receipts created in the period.
-        // For each receipt item, compute net = amountPaid / (1 + vatRate/100)
-        for (const r of receiptsInYear) {
+        // Revenue (without VAT) - calculated from payments created in the period.
+        // For each payment item, compute net = amountPaid / (1 + vatRate/100)
+        for (const r of paymentsInYear) {
             const currency = r.invoice?.currency;
             if (!currency) continue;
             ensureCurrency(currency);
@@ -101,7 +101,7 @@ export class StatsService {
             m.revenue += net;
         }
 
-        // Deposits (invoice paid) - attribute invoice.totalTTC to the month when cumulative receipts reached the invoice total
+        // Deposits (invoice paid) - attribute invoice.totalTTC to the month when cumulative payments reached the invoice total
         for (const p of paidInvoices) {
             const paidDate = new Date(p.paidDate);
             if (paidDate.getFullYear() !== year) continue;
@@ -145,7 +145,7 @@ export class StatsService {
             },
         });
 
-        const receiptsInRange = await prisma.receipt.findMany({
+        const paymentsInRange = await prisma.payment.findMany({
             where: {
                 createdAt: {
                     gte: startDate,
@@ -158,15 +158,15 @@ export class StatsService {
             },
         });
 
-        const invoicesWithReceipts = await prisma.invoice.findMany({
-            where: { isActive: true, receipts: { some: {} } },
-            include: { receipts: { orderBy: { createdAt: 'asc' } } },
+        const invoicesWithPayments = await prisma.invoice.findMany({
+            where: { isActive: true, payments: { some: {} } },
+            include: { payments: { orderBy: { createdAt: 'asc' } } },
         });
 
         const paidInvoices: { invoice: any; paidDate: Date }[] = [];
-        for (const inv of invoicesWithReceipts) {
+        for (const inv of invoicesWithPayments) {
             let cumulative = 0;
-            for (const r of inv.receipts) {
+            for (const r of inv.payments) {
                 cumulative += r.totalPaid;
                 if (cumulative >= inv.totalTTC) {
                     paidInvoices.push({ invoice: inv, paidDate: r.createdAt });
@@ -197,7 +197,7 @@ export class StatsService {
         }
 
         // Revenue
-        for (const r of receiptsInRange) {
+        for (const r of paymentsInRange) {
             const currency = r.invoice?.currency;
             if (!currency) continue;
             ensureCurrencyYears(currency);

--- a/backend/src/modules/webhooks/drivers/event-formatters.ts
+++ b/backend/src/modules/webhooks/drivers/event-formatters.ts
@@ -35,7 +35,16 @@ export const EVENT_STYLES: Record<WebhookEvent, EventStyle> = {
     [WebhookEvent.INVOICE_SEARCHED]: { color: "#6b7280", emoji: "🔍", title: "Invoice Searched" },
     [WebhookEvent.INVOICE_STATUS_CHANGED]: { color: "#10b981", emoji: "🔄", title: "Invoice Status Changed" },
 
-    // Receipt events - Purple
+    // Payment document events - Purple
+    [WebhookEvent.PAYMENT_CREATED]: { color: "#8b5cf6", emoji: "🧾", title: "Payment Created" },
+    [WebhookEvent.PAYMENT_UPDATED]: { color: "#8b5cf6", emoji: "✏️", title: "Payment Updated" },
+    [WebhookEvent.PAYMENT_DELETED]: { color: "#ef4444", emoji: "🗑️", title: "Payment Deleted" },
+    [WebhookEvent.PAYMENT_SENT]: { color: "#8b5cf6", emoji: "📧", title: "Payment Sent" },
+    [WebhookEvent.PAYMENT_PDF_GENERATED]: { color: "#6366f1", emoji: "📄", title: "Payment PDF Generated" },
+    [WebhookEvent.PAYMENT_CREATED_FROM_INVOICE]: { color: "#8b5cf6", emoji: "🔄", title: "Payment Created from Invoice" },
+    [WebhookEvent.PAYMENT_SEARCHED]: { color: "#6b7280", emoji: "🔍", title: "Payment Searched" },
+
+    // Receipt events - Purple (deprecated, use PAYMENT_* instead)
     [WebhookEvent.RECEIPT_CREATED]: { color: "#8b5cf6", emoji: "🧾", title: "Receipt Created" },
     [WebhookEvent.RECEIPT_UPDATED]: { color: "#8b5cf6", emoji: "✏️", title: "Receipt Updated" },
     [WebhookEvent.RECEIPT_DELETED]: { color: "#ef4444", emoji: "🗑️", title: "Receipt Deleted" },
@@ -146,6 +155,9 @@ export const EVENT_STYLES: Record<WebhookEvent, EventStyle> = {
     [WebhookEvent.INVOICE_ITEM_CREATED]: { color: "#10b981", emoji: "➕", title: "Invoice Item Created" },
     [WebhookEvent.INVOICE_ITEM_UPDATED]: { color: "#10b981", emoji: "✏️", title: "Invoice Item Updated" },
     [WebhookEvent.INVOICE_ITEM_DELETED]: { color: "#ef4444", emoji: "➖", title: "Invoice Item Deleted" },
+    [WebhookEvent.PAYMENT_ITEM_CREATED]: { color: "#8b5cf6", emoji: "➕", title: "Payment Item Created" },
+    [WebhookEvent.PAYMENT_ITEM_UPDATED]: { color: "#8b5cf6", emoji: "✏️", title: "Payment Item Updated" },
+    [WebhookEvent.PAYMENT_ITEM_DELETED]: { color: "#ef4444", emoji: "➖", title: "Payment Item Deleted" },
     [WebhookEvent.RECEIPT_ITEM_CREATED]: { color: "#8b5cf6", emoji: "➕", title: "Receipt Item Created" },
     [WebhookEvent.RECEIPT_ITEM_UPDATED]: { color: "#8b5cf6", emoji: "✏️", title: "Receipt Item Updated" },
     [WebhookEvent.RECEIPT_ITEM_DELETED]: { color: "#ef4444", emoji: "➖", title: "Receipt Item Deleted" },
@@ -161,6 +173,7 @@ export const EVENT_STYLES: Record<WebhookEvent, EventStyle> = {
     // Number formatting events
     [WebhookEvent.QUOTE_NUMBER_GENERATED]: { color: "#3b82f6", emoji: "🔢", title: "Quote Number Generated" },
     [WebhookEvent.INVOICE_NUMBER_GENERATED]: { color: "#10b981", emoji: "🔢", title: "Invoice Number Generated" },
+    [WebhookEvent.PAYMENT_NUMBER_GENERATED]: { color: "#8b5cf6", emoji: "🔢", title: "Payment Number Generated" },
     [WebhookEvent.RECEIPT_NUMBER_GENERATED]: { color: "#8b5cf6", emoji: "🔢", title: "Receipt Number Generated" },
 
     // Background process events
@@ -234,7 +247,21 @@ export function formatPayloadForEvent(event: WebhookEvent, payload: any): string
         [WebhookEvent.INVOICE_STATUS_CHANGED]: (p) =>
             `**Invoice #${p.invoice?.number || p.invoiceId}**\nNew status: ${p.newStatus || 'N/A'}`,
 
-        // Receipt events
+        // Payment document events
+        [WebhookEvent.PAYMENT_CREATED]: (p) =>
+            `**Payment #${p.payment?.number || p.paymentId}**\nInvoice: #${p.invoice?.number || 'N/A'}\nAmount: ${p.payment?.totalPaid || 0}${p.invoice?.currency || '€'}`,
+        [WebhookEvent.PAYMENT_UPDATED]: (p) =>
+            `**Payment #${p.payment?.number || p.paymentId}**\nInvoice: #${p.invoice?.number || 'N/A'}`,
+        [WebhookEvent.PAYMENT_DELETED]: (p) =>
+            `**Payment #${p.payment?.number || p.paymentId}**\nInvoice: #${p.invoice?.number || 'N/A'}`,
+        [WebhookEvent.PAYMENT_SENT]: (p) =>
+            `**Payment #${p.payment?.number || p.paymentId}**\nInvoice: #${p.invoice?.number || 'N/A'}`,
+        [WebhookEvent.PAYMENT_PDF_GENERATED]: (p) => null,
+        [WebhookEvent.PAYMENT_CREATED_FROM_INVOICE]: (p) =>
+            `**Payment #${p.payment?.number || p.paymentId}**\nFrom Invoice #${p.invoice?.number || 'N/A'}`,
+        [WebhookEvent.PAYMENT_SEARCHED]: (p) => null,
+
+        // Receipt events (deprecated, use PAYMENT_* instead)
         [WebhookEvent.RECEIPT_CREATED]: (p) =>
             `**Receipt #${p.receipt?.number || p.receiptId}**\nInvoice: #${p.invoice?.number || 'N/A'}\nAmount: ${p.receipt?.totalPaid || 0}${p.invoice?.currency || '€'}`,
         [WebhookEvent.RECEIPT_UPDATED]: (p) =>
@@ -406,6 +433,12 @@ export function formatPayloadForEvent(event: WebhookEvent, payload: any): string
             `Invoice: #${p.invoice?.number || 'N/A'}\nItem: ${p.item?.description || 'N/A'}`,
         [WebhookEvent.INVOICE_ITEM_DELETED]: (p) =>
             `Invoice: #${p.invoice?.number || 'N/A'}`,
+        [WebhookEvent.PAYMENT_ITEM_CREATED]: (p) =>
+            `Payment: #${p.payment?.number || 'N/A'}\nItem: ${p.item?.description || 'N/A'}`,
+        [WebhookEvent.PAYMENT_ITEM_UPDATED]: (p) =>
+            `Payment: #${p.payment?.number || 'N/A'}\nItem: ${p.item?.description || 'N/A'}`,
+        [WebhookEvent.PAYMENT_ITEM_DELETED]: (p) =>
+            `Payment: #${p.payment?.number || 'N/A'}`,
         [WebhookEvent.RECEIPT_ITEM_CREATED]: (p) =>
             `Receipt: #${p.receipt?.number || 'N/A'}\nItem: ${p.item?.description || 'N/A'}`,
         [WebhookEvent.RECEIPT_ITEM_UPDATED]: (p) =>
@@ -432,6 +465,8 @@ export function formatPayloadForEvent(event: WebhookEvent, payload: any): string
             `Quote number: ${p.number || 'N/A'}`,
         [WebhookEvent.INVOICE_NUMBER_GENERATED]: (p) =>
             `Invoice number: ${p.number || 'N/A'}`,
+        [WebhookEvent.PAYMENT_NUMBER_GENERATED]: (p) =>
+            `Payment number: ${p.number || 'N/A'}`,
         [WebhookEvent.RECEIPT_NUMBER_GENERATED]: (p) =>
             `Receipt number: ${p.number || 'N/A'}`,
 

--- a/backend/src/prisma/prisma.service.ts
+++ b/backend/src/prisma/prisma.service.ts
@@ -13,9 +13,9 @@ const prisma = new PrismaClient({ adapter }).$extends({
         $allModels: {
             async findMany({ model, operation, args, query }) {
                 if (
-                    ['Quote', 'Invoice', 'Receipt'].includes(model) &&
+                    ['Quote', 'Invoice', 'Payment'].includes(model) &&
                     args?.where &&
-                    (args.where as Prisma.QuoteWhereInput | Prisma.InvoiceWhereInput | Prisma.ReceiptWhereInput).rawNumber! === null
+                    (args.where as Prisma.QuoteWhereInput | Prisma.InvoiceWhereInput | Prisma.PaymentWhereInput).rawNumber! === null
                 ) {
                     return query(args);
                 }
@@ -24,7 +24,7 @@ const prisma = new PrismaClient({ adapter }).$extends({
                 const result = await query(args);
 
                 // Mise à jour automatique des rawNumber manquants
-                if (['Quote', 'Invoice', 'Receipt'].includes(model)) {
+                if (['Quote', 'Invoice', 'Payment'].includes(model)) {
                     if (model === 'Quote') {
                         const toUpdate = await prisma.quote.findMany({
                             where: { rawNumber: null },
@@ -65,20 +65,20 @@ const prisma = new PrismaClient({ adapter }).$extends({
                         );
                     }
 
-                    if (model === 'Receipt') {
-                        const toUpdate = await prisma.receipt.findMany({
+                    if (model === 'Payment') {
+                        const toUpdate = await prisma.payment.findMany({
                             where: { rawNumber: null },
                             include: { invoice: { include: { company: true } } },
                         });
                         await Promise.all(
-                            toUpdate.map(async (receipt) => {
+                            toUpdate.map(async (payment) => {
                                 const formattedNumber = await formatPattern(
-                                    'receipt',
-                                    receipt.number,
-                                    receipt.createdAt,
+                                    'payment',
+                                    payment.number,
+                                    payment.createdAt,
                                 );
-                                await prisma.receipt.update({
-                                    where: { id: receipt.id },
+                                await prisma.payment.update({
+                                    where: { id: payment.id },
                                     data: { rawNumber: formattedNumber },
                                 });
                             }),
@@ -92,11 +92,11 @@ const prisma = new PrismaClient({ adapter }).$extends({
             async create({ model, args, query }) {
                 const result = (await query(args));
 
-                if (['Quote', 'Invoice', 'Receipt'].includes(model)) {
-                    const typedResult = result as Prisma.QuoteGetPayload<{}> | Prisma.InvoiceGetPayload<{}> | Prisma.ReceiptGetPayload<{}>;
+                if (['Quote', 'Invoice', 'Payment'].includes(model)) {
+                    const typedResult = result as Prisma.QuoteGetPayload<{}> | Prisma.InvoiceGetPayload<{}> | Prisma.PaymentGetPayload<{}>;
                     if (!typedResult.rawNumber) {
                         const formattedNumber = await formatPattern(
-                            (model.toLowerCase() as 'quote' | 'invoice' | 'receipt'),
+                            (model.toLowerCase() as 'quote' | 'invoice' | 'payment'),
                             typedResult.number,
                             typedResult.createdAt,
                         );
@@ -113,11 +113,11 @@ const prisma = new PrismaClient({ adapter }).$extends({
             async update({ model, args, query }) {
                 const result = await query(args);
 
-                if (['Quote', 'Invoice', 'Receipt'].includes(model)) {
-                    const typedResult = result as Prisma.QuoteGetPayload<{}> | Prisma.InvoiceGetPayload<{}> | Prisma.ReceiptGetPayload<{}>;
+                if (['Quote', 'Invoice', 'Payment'].includes(model)) {
+                    const typedResult = result as Prisma.QuoteGetPayload<{}> | Prisma.InvoiceGetPayload<{}> | Prisma.PaymentGetPayload<{}>;
                     if (!typedResult.rawNumber) {
                         const formattedNumber = await formatPattern(
-                            (model.toLowerCase() as 'quote' | 'invoice' | 'receipt'),
+                            (model.toLowerCase() as 'quote' | 'invoice' | 'payment'),
                             typedResult.number,
                             typedResult.createdAt,
                         );
@@ -159,7 +159,8 @@ export class PrismaService implements OnModuleInit, OnModuleDestroy {
     get client_model() { return this.client.client; }
     get quote() { return this.client.quote; }
     get invoice() { return this.client.invoice; }
-    get receipt() { return this.client.receipt; }
+    get payment() { return this.client.payment; }
+    get paymentItem() { return this.client.paymentItem; }
     get recurringInvoice() { return this.client.recurringInvoice; }
     get paymentMethod() { return this.client.paymentMethod; }
     get webhook() { return this.client.webhook; }

--- a/backend/src/utils/pdf.ts
+++ b/backend/src/utils/pdf.ts
@@ -6,7 +6,7 @@ import { BadRequestException } from '@nestjs/common';
 import { PrismaClient } from '../../prisma/generated/prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 
-type PatternType = "receipt" | "invoice" | "quote";
+type PatternType = "payment" | "invoice" | "quote";
 
 export async function formatPattern(type: PatternType, number: number, date: Date = new Date()): Promise<string> {
     const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
@@ -19,7 +19,7 @@ export async function formatPattern(type: PatternType, number: number, date: Dat
     let pattern = '';
     let startingNumber = 1;
     switch (type) {
-        case "receipt":
+        case "payment":
             pattern = company.paymentNumberFormat;
             startingNumber = company.paymentStartingNumber;
             break;

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -433,7 +433,7 @@
             "messages": {
                 "markAsPaidSuccess": "Rechnung als erfolgreich bezahlt markiert",
                 "markAsPaidError": "Rechnung konnte nicht als bezahlt markiert werden",
-                "createReceiptSuccess": "Beleg erfolgreich aus Rechnung erstellt",
+                "createPaymentSuccess": "Zahlung erfolgreich aus Rechnung erstellt",
                 "sendByEmailSuccess": "Rechnung wurde versandt"
             }
         },
@@ -1588,7 +1588,7 @@
             "signed": "Unterzeichnet"
         },
         "emptyState": {
-            "noReceipts": "Noch keine Belege",
+            "noPayments": "Noch keine Zahlungen",
             "noResults": "Keine Belege gefunden",
             "startAdding": "Beginnen Sie mit der Erstellung Ihres ersten Belegs.",
             "tryDifferentSearch": "Versuchen Sie, Ihre Suchbegriffe anzupassen."

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -517,7 +517,7 @@
             "messages": {
                 "markAsPaidSuccess": "Invoice marked as paid successfully",
                 "markAsPaidError": "Failed to mark invoice as paid",
-                "createReceiptSuccess": "Receipt created successfully from invoice",
+                "createPaymentSuccess": "Payment created successfully from invoice",
                 "sendByEmailSuccess": "Invoice has been sent to customer",
                 "archiveSuccess": "Invoice archived successfully",
                 "archiveError": "Failed to archive invoice"

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -433,7 +433,7 @@
             "messages": {
                 "markAsPaidSuccess": "Factura marcada como pagada con éxito",
                 "markAsPaidError": "Error al marcar la factura como pagada",
-                "createReceiptSuccess": "Recibo creado correctamente desde la factura",
+                "createPaymentSuccess": "Pago creado correctamente desde la factura",
                 "sendByEmailSuccess": "La factura fue enviada al cliente"
             }
         },
@@ -1588,7 +1588,7 @@
             "signed": "Firmada"
         },
         "emptyState": {
-            "noReceipts": "Aún no hay recibos",
+            "noPayments": "Aún no hay pagos",
             "noResults": "No se encontraron recibos",
             "startAdding": "Comienza creando tu primer recibo.",
             "tryDifferentSearch": "Prueba ajustando tus términos de búsqueda."

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -518,7 +518,7 @@
             "messages": {
                 "markAsPaidSuccess": "Facture marquée comme payée avec succès",
                 "markAsPaidError": "Échec du marquage de la facture comme payée",
-                "createReceiptSuccess": "Reçu créé avec succès à partir de la facture",
+                "createPaymentSuccess": "Paiement créé avec succès à partir de la facture",
                 "sendByEmailSuccess": "La facture a été envoyée au client",
                 "archiveSuccess": "Facture archivée avec succès",
                 "archiveError": "Échec de l'archivage de la facture"
@@ -1767,7 +1767,7 @@
             "signed": "Signé"
         },
         "emptyState": {
-            "noReceipts": "Aucun paiement pour le moment",
+            "noPayments": "Aucun paiement pour le moment",
             "noResults": "Aucun paiement trouvé",
             "startAdding": "Commencez par créer votre premier paiement.",
             "tryDifferentSearch": "Essayez d'ajuster vos termes de recherche."
@@ -1804,7 +1804,7 @@
                 "emailError": "Échec de l'envoi du paiement au client."
             },
             "actions": {
-                "addNew": "Ajouter un nouveau reçu"
+                "addNew": "Ajouter un nouveau paiement"
             }
         },
         "upsert": {

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -409,7 +409,7 @@
             "signed": "Ondertekend"
         },
         "emptyState": {
-            "noReceipts": "Nog geen bonnen",
+            "noPayments": "Nog geen betalingen",
             "noResults": "Geen bonnen gevonden",
             "startAdding": "Begin met het maken van je eerste bon.",
             "tryDifferentSearch": "Pas uw zoekopdracht aan."

--- a/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
@@ -138,7 +138,7 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
         function handleCreatePaymentFromInvoice(invoiceId: string) {
             triggerCreatePayment({ id: invoiceId })
                 .then(() => {
-                    toast.success(t("invoices.list.messages.createReceiptSuccess"))
+                    toast.success(t("invoices.list.messages.createPaymentSuccess"))
                     queryClient.invalidateQueries({ queryKey: queryKeys.payments.listsAll() })
                     queryClient.invalidateQueries({ queryKey: queryKeys.invoices.listsAll() })
                 })

--- a/frontend/src/pages/(app)/settings/_components/pdf.settings.tsx
+++ b/frontend/src/pages/(app)/settings/_components/pdf.settings.tsx
@@ -364,7 +364,7 @@ const defaultPaymentTemplate = `
 </html>
 `
 interface TemplateSettings {
-    templateType: "invoice" | "quote" | "receipt"
+    templateType: "invoice" | "quote" | "payment"
     fontFamily: string
     primaryColor: string
     secondaryColor: string
@@ -658,7 +658,7 @@ export default function PDFTemplatesSettings() {
                                                 <Label htmlFor="template-type">{t("settings.pdfTemplates.templateType.label")}</Label>
                                                 <Select
                                                     value={settings.templateType}
-                                                    onValueChange={(value: "invoice" | "quote" | "receipt") =>
+                                                    onValueChange={(value: "invoice" | "quote" | "payment") =>
                                                         setSettings((prev) => ({ ...prev, templateType: value }))
                                                     }
                                                 >
@@ -672,8 +672,8 @@ export default function PDFTemplatesSettings() {
                                                         <SelectItem value="quote">
                                                             {t("settings.pdfTemplates.templateType.options.quote")}
                                                         </SelectItem>
-                                                        <SelectItem value="receipt">
-                                                            {t("settings.pdfTemplates.templateType.options.receipt")}
+                                                        <SelectItem value="payment">
+                                                            {t("settings.pdfTemplates.templateType.options.payment")}
                                                         </SelectItem>
                                                     </SelectContent>
                                                 </Select>


### PR DESCRIPTION
Closes #331

Finish the receipt -> payment refactor down to the data and naming layer.

- DB: rename Receipt/ReceiptItem models to Payment/PaymentItem, receiptId ->
  paymentId, PDFConfig.receipt label -> payment; constraints renamed to Prisma
  conventions. Two migrations preserve existing data and migrate MailTemplate
  rows RECEIPT -> PAYMENT.
- Enums: add PAYMENT_* WebhookEvent values and MailTemplateType.PAYMENT, keeping the RECEIPT_* / RECEIPT values as deprecated aliases.
- Webhooks: dispatch new PAYMENT_* events with dual-dispatch of the deprecated RECEIPT_* aliases (payload exposes both `payment` and `receipt`) so existing subscriptions keep working; formatters extended accordingly.
- Backend: update prisma.service, pdf.ts PatternType, payments.service, stats.service, base template and company seed/labels.
- Frontend/i18n: templateType "receipt" -> "payment", rename createReceiptSuccess -> createPaymentSuccess and noReceipts -> noPayments, fix stray FR "reçu" label.

The deprecated /receipts controller and the RECEIPT_* enum values are kept intentionally for backward compatibility.