### PR TITLE
feat(invoices): add DRAFT watermark on PDF and in-app preview (#339)

### DIFF
--- a/backend/src/modules/invoices/invoices.service.ts
+++ b/backend/src/modules/invoices/invoices.service.ts
@@ -17,6 +17,7 @@ import { logger } from '@/logger/logger.service';
 import { parseAddress } from '@/utils/adress';
 import prisma from '@/prisma/prisma.service';
 import { calculateDiscountedTotals, clampDiscountRate } from '@/utils/financial';
+import { getDraftWatermarkLabel } from '@/utils/watermark';
 
 @Injectable()
 export class InvoicesService {
@@ -373,6 +374,8 @@ export class InvoicesService {
         const hasDiscount = normalizedDiscountRate > 0 && discountAmountValue > 0;
 
         const html = template({
+            isDraft: invoice.status === 'DRAFT',
+            draftLabel: getDraftWatermarkLabel(invoice.company.country),
             number: invoice.rawNumber || invoice.number.toString(),
             date: formatDate(invoice.company, invoice.createdAt),
             dueDate: formatDate(invoice.company, invoice.dueDate),
@@ -435,7 +438,7 @@ export class InvoicesService {
                 day: pdfConfig.day,
                 deposit: pdfConfig.deposit,
                 service: pdfConfig.service,
-                product: pdfConfig.product
+                product: pdfConfig.product,
             },
         });
 

--- a/backend/src/modules/invoices/templates/base.template.ts
+++ b/backend/src/modules/invoices/templates/base.template.ts
@@ -17,9 +17,25 @@ export const baseTemplate = `
         .notes { margin-top: 30px; padding: 20px; background-color: {{secondaryColor}}; border-radius: 4px; color: {{tableTextColor}}; }
         .payment-info { margin-top: 20px; padding: 15px; background-color: #f9f9f9; border-left: 4px solid {{primaryColor}}; color: #333; }
         .logo { max-height: 80px; margin-bottom: 10px; }
+        .watermark {
+            position: fixed;
+            top: 45%;
+            left: 50%;
+            transform: translate(-50%, -50%) rotate(-30deg);
+            font-size: 96px;
+            font-weight: bold;
+            color: #ff0000;
+            opacity: 0.15;
+            z-index: 1000;
+            pointer-events: none;
+            white-space: nowrap;
+        }
     </style>
 </head>
 <body>
+    {{#if isDraft}}
+    <div class="watermark">{{draftLabel}}</div>
+    {{/if}}
     <div class="header">
         <div class="company-info">
             {{#if includeLogo}}

--- a/backend/src/utils/watermark.ts
+++ b/backend/src/utils/watermark.ts
@@ -1,0 +1,61 @@
+// ISO 3166-1 alpha-2 country codes — keep in sync with frontend/src/lib/constants/countries.ts
+// (the list backing the CountrySelect component).
+const countryCodes = [
+    "AF", "AL", "DZ", "AD", "AO", "AG", "AR", "AM", "AU", "AT",
+    "AZ", "BS", "BH", "BD", "BB", "BY", "BE", "BZ", "BJ", "BT",
+    "BO", "BA", "BW", "BR", "BN", "BG", "BF", "BI", "CV", "KH",
+    "CM", "CA", "CF", "TD", "CL", "CN", "CO", "KM", "CG", "CD",
+    "CR", "CI", "HR", "CU", "CY", "CZ", "DK", "DJ", "DM", "DO",
+    "EC", "EG", "SV", "GQ", "ER", "EE", "SZ", "ET", "FJ", "FI",
+    "FR", "GA", "GM", "GE", "DE", "GH", "GR", "GD", "GT", "GN",
+    "GW", "GY", "HT", "HN", "HU", "IS", "IN", "ID", "IR", "IQ",
+    "IE", "IL", "IT", "JM", "JP", "JO", "KZ", "KE", "KI", "KP",
+    "KR", "KW", "KG", "LA", "LV", "LB", "LS", "LR", "LY", "LI",
+    "LT", "LU", "MG", "MW", "MY", "MV", "ML", "MT", "MH", "MR",
+    "MU", "MX", "FM", "MD", "MC", "MN", "ME", "MA", "MZ", "MM",
+    "NA", "NR", "NP", "NL", "NZ", "NI", "NE", "NG", "MK", "NO",
+    "OM", "PK", "PW", "PA", "PG", "PY", "PE", "PH", "PL", "PT",
+    "QA", "RO", "RU", "RW", "KN", "LC", "VC", "WS", "SM", "ST",
+    "SA", "SN", "RS", "SC", "SL", "SG", "SK", "SI", "SB", "SO",
+    "ZA", "SS", "ES", "LK", "SD", "SR", "SE", "CH", "SY", "TJ",
+    "TZ", "TH", "TL", "TG", "TO", "TT", "TN", "TR", "TM", "TV",
+    "UG", "UA", "AE", "GB", "US", "UY", "UZ", "VU", "VA", "VE",
+    "VN", "YE", "ZM", "ZW",
+];
+
+// Resolved against the same country list used by the frontend CountrySelect, since the saved
+// Company.country value is a localized display name (e.g. "Germany"/"Allemagne"/"Deutschland")
+// rather than an ISO code.
+const RESOLVABLE_LOCALES = ['en', 'fr', 'de', 'es'];
+
+const DRAFT_LABEL_BY_LANGUAGE: Record<string, string> = {
+    fr: 'BROUILLON',
+    de: 'ENTWURF',
+    es: 'BORRADOR',
+};
+
+// Only countries whose main official language is one we have a translated word for.
+const LANGUAGE_BY_COUNTRY_CODE: Record<string, string> = {
+    FR: 'fr', MC: 'fr',
+    DE: 'de', AT: 'de',
+    ES: 'es', MX: 'es', AR: 'es', CO: 'es', CL: 'es', PE: 'es', VE: 'es',
+    EC: 'es', GT: 'es', CU: 'es', BO: 'es', DO: 'es', HN: 'es', PY: 'es',
+    SV: 'es', NI: 'es', CR: 'es', PA: 'es', UY: 'es',
+};
+
+const resolveCountryCode = (country: string): string | null => {
+    const normalized = country.trim().toLowerCase();
+    for (const locale of RESOLVABLE_LOCALES) {
+        const displayNames = new Intl.DisplayNames([locale], { type: 'region' });
+        const match = countryCodes.find((code) => displayNames.of(code)?.toLowerCase() === normalized);
+        if (match) return match;
+    }
+    return null;
+};
+
+export const getDraftWatermarkLabel = (country?: string | null): string => {
+    if (!country) return 'DRAFT';
+    const code = resolveCountryCode(country);
+    const language = code ? LANGUAGE_BY_COUNTRY_CODE[code] : undefined;
+    return language ? DRAFT_LABEL_BY_LANGUAGE[language] : 'DRAFT';
+};

--- a/frontend/src/lib/watermark.ts
+++ b/frontend/src/lib/watermark.ts
@@ -1,0 +1,38 @@
+import { countryCodes } from "@/lib/constants/countries"
+
+// Resolved against the same country list used by CountrySelect (frontend/src/components/country-select.tsx),
+// since the saved Company.country value is a localized display name (e.g. "Germany"/"Allemagne"/"Deutschland")
+// rather than an ISO code.
+const RESOLVABLE_LOCALES = ["en", "fr", "de", "es"]
+
+const DRAFT_LABEL_BY_LANGUAGE: Record<string, string> = {
+    fr: "BROUILLON",
+    de: "ENTWURF",
+    es: "BORRADOR",
+}
+
+// Only countries whose main official language is one we have a translated word for.
+const LANGUAGE_BY_COUNTRY_CODE: Record<string, string> = {
+    FR: "fr", MC: "fr",
+    DE: "de", AT: "de",
+    ES: "es", MX: "es", AR: "es", CO: "es", CL: "es", PE: "es", VE: "es",
+    EC: "es", GT: "es", CU: "es", BO: "es", DO: "es", HN: "es", PY: "es",
+    SV: "es", NI: "es", CR: "es", PA: "es", UY: "es",
+}
+
+const resolveCountryCode = (country: string): string | null => {
+    const normalized = country.trim().toLowerCase()
+    for (const locale of RESOLVABLE_LOCALES) {
+        const displayNames = new Intl.DisplayNames([locale], { type: "region" })
+        const match = countryCodes.find((code) => displayNames.of(code)?.toLowerCase() === normalized)
+        if (match) return match
+    }
+    return null
+}
+
+export const getDraftWatermarkLabel = (country?: string | null): string => {
+    if (!country) return "DRAFT"
+    const code = resolveCountryCode(country)
+    const language = code ? LANGUAGE_BY_COUNTRY_CODE[code] : undefined
+    return language ? DRAFT_LABEL_BY_LANGUAGE[language] : "DRAFT"
+}

--- a/frontend/src/pages/(app)/invoices/_components/invoice-view.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-view.tsx
@@ -4,6 +4,7 @@ import type { Invoice, PaymentMethod } from "@/types"
 import { PaymentMethodType, getDisplayInvoiceStatus } from "@/types"
 import { format } from "date-fns"
 import { languageToLocale } from "@/lib/i18n"
+import { getDraftWatermarkLabel } from "@/lib/watermark"
 import { useTranslation } from "react-i18next"
 
 interface InvoiceViewDialogProps {
@@ -27,7 +28,14 @@ export function InvoiceViewDialog({ invoice, onOpenChange }: InvoiceViewDialogPr
 
     return (
         <Dialog open={!!invoice} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-[95vw] lg:max-w-3xl max-h-[90dvh] flex flex-col">
+            <DialogContent className="max-w-[95vw] lg:max-w-3xl max-h-[90dvh] flex flex-col relative overflow-hidden">
+                {invoice.status === "DRAFT" && (
+                    <div className="pointer-events-none absolute inset-0 flex items-center justify-center z-50 overflow-hidden">
+                        <span className="text-8xl font-bold text-red-500/15 -rotate-[30deg] select-none whitespace-nowrap">
+                            {getDraftWatermarkLabel(invoice.company?.country)}
+                        </span>
+                    </div>
+                )}
                 <DialogHeader className="flex-shrink-0">
                     <DialogTitle className="text-xl font-semibold">
                         {t("invoices.view.title", { number: invoice.number })}


### PR DESCRIPTION
Closes #339 

Drafts had no visual distinction from finalized invoices once a PDF was generated, risking accidental sending. Watermark text is resolved to the company's country language (via the same ISO list as CountrySelect) and disappears once the invoice status changes.