### PR TITLE
feat(invoices): rework invoice list status filters as multi-select

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -383,6 +383,13 @@
             "sent": "Gesendet",
             "paid": "Bezahlt"
         },
+        "statusFilters": {
+            "all": "Alle",
+            "draft": "Entwurf",
+            "sent": "Gesendet",
+            "paid": "Bezahlt",
+            "archived": "Archiviert"
+        },
         "emptyState": {
             "noInvoices": "Noch keine Rechnungen",
             "noResults": "Keine Rechnungen gefunden",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -465,9 +465,10 @@
         },
         "statusFilters": {
             "all": "All",
+            "draft": "Draft",
             "sent": "Sent",
             "paid": "Paid",
-            "unpaid": "Unpaid"
+            "archived": "Archived"
         },
         "emptyState": {
             "noInvoices": "No invoices yet",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -383,6 +383,13 @@
             "sent": "Enviada",
             "paid": "Pagada"
         },
+        "statusFilters": {
+            "all": "Todas",
+            "draft": "Borrador",
+            "sent": "Enviada",
+            "paid": "Pagada",
+            "archived": "Archivada"
+        },
         "emptyState": {
             "noInvoices": "Aún no hay facturas",
             "noResults": "No se encontraron facturas",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -466,9 +466,10 @@
         },
         "statusFilters": {
             "all": "Toutes",
-            "sent": "Envoyées",
-            "paid": "Payées",
-            "unpaid": "Impayées"
+            "draft": "Brouillon",
+            "sent": "Envoyé",
+            "paid": "Payé",
+            "archived": "Archivé"
         },
         "emptyState": {
             "noInvoices": "Aucune facture pour le moment",

--- a/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
@@ -10,7 +10,7 @@ import BetterPagination from "../../../../components/pagination"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { InvoiceStatus, getDisplayInvoiceStatus, type Invoice } from "@/types"
+import { InvoiceStatus, getDisplayInvoiceStatus, type Invoice, type InvoiceStatusFilterKey } from "@/types"
 import { InvoiceDeleteDialog } from "./invoice-delete"
 import { InvoicePdfModal } from "./invoice-pdf-view"
 import { InvoiceUpsert } from "./invoice-upsert"
@@ -27,9 +27,9 @@ interface InvoiceListProps {
     description?: string
     searchTerm?: string
     onSearchChange?: (value: string) => void
-    statusFilter?: "sent" | "paid" | "unpaid"
-    onStatusFilterChange?: (value: "sent" | "paid" | "unpaid" | undefined) => void
-    statusCounts?: { sent: number; paid: number; unpaid: number }
+    statusFilter?: InvoiceStatusFilterKey[]
+    onStatusFilterChange?: (key: InvoiceStatusFilterKey) => void
+    statusCounts?: { draft: number; sent: number; paid: number; archived: number }
     page?: number
     pageCount?: number
     setPage?: (page: number) => void
@@ -220,9 +220,19 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                             {onStatusFilterChange && (
                                 <div className="flex items-center gap-2">
                                     <Badge
-                                        onClick={() => onStatusFilterChange(statusFilter === "sent" ? undefined : "sent")}
+                                        onClick={() => onStatusFilterChange("draft")}
                                         variant="outline"
-                                        className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter === "sent"
+                                        className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter?.includes("draft")
+                                            ? "bg-gray-500 text-white font-semibold shadow-sm scale-105"
+                                            : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                                            }`}
+                                    >
+                                        {t("invoices.statusFilters.draft")} ({statusCounts?.draft ?? 0})
+                                    </Badge>
+                                    <Badge
+                                        onClick={() => onStatusFilterChange("sent")}
+                                        variant="outline"
+                                        className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter?.includes("sent")
                                             ? "bg-yellow-500 text-white font-semibold shadow-sm scale-105"
                                             : "bg-yellow-50 text-yellow-700/70 hover:bg-yellow-100"
                                             }`}
@@ -230,24 +240,24 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                                         {t("invoices.statusFilters.sent")} ({statusCounts?.sent ?? 0})
                                     </Badge>
                                     <Badge
-                                        onClick={() => onStatusFilterChange(statusFilter === "unpaid" ? undefined : "unpaid")}
+                                        onClick={() => onStatusFilterChange("paid")}
                                         variant="outline"
-                                        className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter === "unpaid"
-                                            ? "bg-blue-600 text-white font-semibold shadow-sm scale-105"
-                                            : "bg-blue-50 text-blue-700/70 hover:bg-blue-100"
-                                            }`}
-                                    >
-                                        {t("invoices.statusFilters.unpaid")} ({statusCounts?.unpaid ?? 0})
-                                    </Badge>
-                                    <Badge
-                                        onClick={() => onStatusFilterChange(statusFilter === "paid" ? undefined : "paid")}
-                                        variant="outline"
-                                        className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter === "paid"
+                                        className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter?.includes("paid")
                                             ? "bg-green-600 text-white font-semibold shadow-sm scale-105"
                                             : "bg-green-50 text-green-700/70 hover:bg-green-100"
                                             }`}
                                     >
                                         {t("invoices.statusFilters.paid")} ({statusCounts?.paid ?? 0})
+                                    </Badge>
+                                    <Badge
+                                        onClick={() => onStatusFilterChange("archived")}
+                                        variant="outline"
+                                        className={`cursor-pointer text-sm px-3 py-1 rounded-full transition-all border-transparent ${statusFilter?.includes("archived")
+                                            ? "bg-slate-600 text-white font-semibold shadow-sm scale-105"
+                                            : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                                            }`}
+                                    >
+                                        {t("invoices.statusFilters.archived")} ({statusCounts?.archived ?? 0})
                                     </Badge>
                                 </div>
                             )}

--- a/frontend/src/pages/(app)/invoices/index.tsx
+++ b/frontend/src/pages/(app)/invoices/index.tsx
@@ -9,7 +9,7 @@ import { queryKeys } from "@/lib/query-keys"
 import { useQueryClient } from "@tanstack/react-query"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { InvoiceStatus, type Invoice } from "@/types"
+import { InvoiceStatus, type Invoice, type InvoiceStatusFilterKey } from "@/types"
 import { usePageHeader } from "@/hooks/use-page-header"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
@@ -17,7 +17,6 @@ import { cn } from "@/lib/utils"
 
 type InvoiceFilter = "all" | "oneTime" | "recurring"
 type InvoiceView = "list" | "progression"
-type InvoiceStatusFilter = "sent" | "paid" | "unpaid" | undefined
 
 export default function Invoices() {
     const { t } = useTranslation()
@@ -55,7 +54,17 @@ export default function Invoices() {
     const [searchTerm, setSearchTerm] = useState("")
     const [filter, setFilter] = useState<InvoiceFilter>("all")
     const [view, setView] = useState<InvoiceView>("list")
-    const [statusFilter, setStatusFilter] = useState<InvoiceStatusFilter>(undefined)
+    const [statusFilter, setStatusFilter] = useState<InvoiceStatusFilterKey[]>(["draft", "sent", "paid"])
+
+    const toggleStatusFilter = (key: InvoiceStatusFilterKey) => {
+        setStatusFilter((current) => (current.includes(key) ? current.filter((k) => k !== key) : [...current, key]))
+    }
+
+    const getStatusFilterKey = (invoice: Invoice): InvoiceStatusFilterKey =>
+        invoice.status === InvoiceStatus.DRAFT ? "draft" :
+        invoice.status === InvoiceStatus.ARCHIVED ? "archived" :
+        invoice.status === InvoiceStatus.PAID ? "paid" :
+        "sent"
 
     const matchesSearch = (invoice: Invoice) =>
         invoice.title?.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -63,11 +72,7 @@ export default function Invoices() {
         invoice.number?.toString().includes(searchTerm) ||
         invoice.client?.name?.toLowerCase().includes(searchTerm.toLowerCase())
 
-    const matchesStatus = (invoice: Invoice) =>
-        !statusFilter ||
-        (statusFilter === "sent" && invoice.status === InvoiceStatus.SENT) ||
-        (statusFilter === "paid" && invoice.status === InvoiceStatus.PAID) ||
-        (statusFilter === "unpaid" && (invoice.status === InvoiceStatus.UNPAID || invoice.status === InvoiceStatus.OVERDUE))
+    const matchesStatus = (invoice: Invoice) => statusFilter.includes(getStatusFilterKey(invoice))
 
     const upcomingInvoices: Invoice[] = (recurringInvoices?.recurringInvoices || [])
         .filter((recurringInvoice) => !!recurringInvoice.nextInvoiceDate)
@@ -106,9 +111,10 @@ export default function Invoices() {
     ]
 
     const invoiceStatusCounts = {
-        sent: invoices?.invoices.filter((i) => i.status === InvoiceStatus.SENT).length || 0,
-        paid: invoices?.invoices.filter((i) => i.status === InvoiceStatus.PAID).length || 0,
-        unpaid: invoices?.invoices.filter((i) => i.status === InvoiceStatus.UNPAID || i.status === InvoiceStatus.OVERDUE).length || 0,
+        draft: invoices?.invoices.filter((i) => getStatusFilterKey(i) === "draft").length || 0,
+        sent: invoices?.invoices.filter((i) => getStatusFilterKey(i) === "sent").length || 0,
+        paid: invoices?.invoices.filter((i) => getStatusFilterKey(i) === "paid").length || 0,
+        archived: invoices?.invoices.filter((i) => getStatusFilterKey(i) === "archived").length || 0,
     }
 
     usePageHeader(t("sidebar.navigation.invoices"))
@@ -227,7 +233,7 @@ export default function Invoices() {
                     searchTerm={searchTerm}
                     onSearchChange={setSearchTerm}
                     statusFilter={statusFilter}
-                    onStatusFilterChange={setStatusFilter}
+                    onStatusFilterChange={toggleStatusFilter}
                     statusCounts={invoiceStatusCounts}
                     page={page}
                     pageCount={invoices?.pageCount || 1}

--- a/frontend/src/types/invoice.ts
+++ b/frontend/src/types/invoice.ts
@@ -20,6 +20,12 @@ export function getDisplayInvoiceStatus(status: InvoiceStatus | string): Invoice
     return status === InvoiceStatus.UNPAID ? InvoiceStatus.SENT : (status as InvoiceStatus)
 }
 
+/**
+ * Groups raw invoice statuses into the 4 categories filterable from the invoice list:
+ * SENT/UNPAID/OVERDUE are grouped under "sent".
+ */
+export type InvoiceStatusFilterKey = "draft" | "sent" | "paid" | "archived"
+
 export enum InvoiceItemType {
     HOUR = "HOUR",
     DAY = "DAY",


### PR DESCRIPTION
Replace the single-select sent/unpaid/paid badges with four toggleable filters (draft, sent, paid, archived) so drafts and archived invoices can finally be shown/hidden from the list. Archived is off by default; sent groups SENT, UNPAID and OVERDUE as before.