### PR TITLE
fix(auth): send name on sign-up so better-auth 1.6 validation passes

### DIFF
--- a/frontend/src/pages/auth/sign-up.tsx
+++ b/frontend/src/pages/auth/sign-up.tsx
@@ -120,6 +120,9 @@ export default function SignupPage() {
         const result = await authClient.signUp.email({
             email: data.email,
             password: data.password,
+            // better-auth >=1.6 requires `name` on email sign-up; derive it from the
+            // first/last name (the backend create hook recomputes the same value).
+            name: `${data.firstname} ${data.lastname}`.trim(),
             // @ts-ignore additional fields
             firstname: data.firstname,
             lastname: data.lastname,


### PR DESCRIPTION
better-auth 1.6 now requires a `name` field on the email sign-up body schema, which is validated before our user-create hook (that derives name from firstname/lastname) runs — so registration failed with "[body.name] Invalid input: expected string, received undefined".

Derive and send name from firstname + lastname in the sign-up call; firstname/lastname are still sent as additional fields and the backend hook recomputes the same name, so there's no behavior change otherwise.