### PR TITLE
Tighten invoice lifecycle: payment-driven status, draft-only deletion, and PDF export rework

### DIFF
--- a/backend/src/modules/invoices/invoices.controller.ts
+++ b/backend/src/modules/invoices/invoices.controller.ts
@@ -144,14 +144,6 @@ export class InvoicesController {
     return this.invoicesService.createInvoiceFromQuote(quoteId);
   }
 
-  @Post('mark-as-paid')
-  @ApiOperation({ summary: 'Mark invoice as paid', description: 'Marks an invoice as paid with the current date.' })
-  @ApiResponse({ status: 201, description: 'Invoice marked as paid' })
-  @ApiBody({ schema: { type: 'object', properties: { invoiceId: { type: 'string', description: 'ID of the invoice to mark as paid' } } } })
-  markInvoiceAsPaid(@Body('invoiceId') invoiceId: string) {
-    return this.invoicesService.markInvoiceAsPaid(invoiceId);
-  }
-
   @Post()
   @ApiOperation({ summary: 'Create an invoice', description: 'Creates a new invoice with items, client, and pricing information.' })
   @ApiResponse({ status: 201, description: 'Invoice created' })

--- a/backend/src/modules/invoices/invoices.service.ts
+++ b/backend/src/modules/invoices/invoices.service.ts
@@ -287,6 +287,11 @@ export class InvoicesService {
             throw new BadRequestException('Invoice not found');
         }
 
+        if (existingInvoice.status !== 'DRAFT') {
+            logger.error('Only draft invoices can be deleted', { category: 'invoice', details: { invoiceId: id, status: existingInvoice.status } });
+            throw new BadRequestException('Only draft invoices can be deleted');
+        }
+
         const deletedInvoice = await prisma.invoice.update({
             where: { id },
             data: { isActive: false },

--- a/backend/src/modules/invoices/invoices.service.ts
+++ b/backend/src/modules/invoices/invoices.service.ts
@@ -196,6 +196,11 @@ export class InvoicesService {
             throw new BadRequestException('Invoice not found');
         }
 
+        if (existingInvoice.status !== 'DRAFT') {
+            logger.error('Only draft invoices can be edited', { category: 'invoice', details: { invoiceId: id, status: existingInvoice.status } });
+            throw new BadRequestException('Only draft invoices can be edited');
+        }
+
         const existingItemIds = existingInvoice.items.map(i => i.id);
         const incomingItemIds = items.filter(i => i.id).map(i => i.id!);
 

--- a/backend/src/modules/invoices/invoices.service.ts
+++ b/backend/src/modules/invoices/invoices.service.ts
@@ -6,7 +6,6 @@ import { EInvoice, ExportFormat } from '@fin.cx/einvoice';
 import { getInvertColor, getPDF } from '@/utils/pdf';
 
 import { MailService } from '@/mail/mail.service';
-import { StorageUploadService } from '@/utils/storage-upload';
 import { WebhookDispatcherService } from '../webhooks/webhook-dispatcher.service';
 import { WebhookEvent } from '../../../prisma/generated/prisma/client';
 import { baseTemplate } from '@/modules/invoices/templates/base.template';
@@ -638,56 +637,6 @@ export class InvoicesService {
         }
 
         return newInvoice;
-    }
-
-    async markInvoiceAsPaid(invoiceId: string) {
-        const invoice = await prisma.invoice.findUnique({
-            where: { id: invoiceId },
-            include: {
-                items: true,
-                client: true,
-                company: true,
-            }
-        });
-
-        if (!invoice) {
-            logger.error('Invoice not found when trying to mark as paid', { category: 'invoice', details: { invoiceId } });
-            throw new BadRequestException('Invoice not found');
-        }
-
-        const paidInvoice = await prisma.invoice.update({
-            where: { id: invoiceId },
-            data: { status: 'PAID', paidAt: new Date() }
-        });
-
-        logger.info('Invoice marked as paid', { category: 'invoice', details: { invoiceId } });
-
-        try {
-            await this.webhookDispatcher.dispatch(WebhookEvent.INVOICE_MARKED_AS_PAID, {
-                invoice: paidInvoice,
-                client: invoice.client,
-                company: invoice.company,
-                paidAt: paidInvoice.paidAt,
-            });
-        } catch (error) {
-            logger.error('Failed to dispatch INVOICE_MARKED_AS_PAID webhook', { category: 'invoice', details: { error } });
-        }
-
-        try {
-            logger.info(`Uploading paid invoice ${invoiceId} to storage providers...`, { category: 'invoice' });
-            const pdfBuffer = await this.getInvoicePdf(invoiceId);
-            const uploadedUrls = await StorageUploadService.uploadPaidInvoicePdf(invoiceId, pdfBuffer);
-            if (uploadedUrls.length > 0) {
-                logger.info(`Invoice ${invoiceId} successfully uploaded to ${uploadedUrls.length} storage provider(s)`, { category: 'invoice', details: { uploadedUrls } });
-            }
-        } catch (error) {
-            logger.error(
-                `Failed to upload paid invoice ${invoiceId} to storage providers`,
-                { category: 'invoice', details: { error: error instanceof Error ? error.message : String(error) } }
-            );
-        }
-
-        return paidInvoice;
     }
 
     async archiveInvoice(invoiceId: string) {

--- a/e2e/cypress/e2e/07-invoices.cy.ts
+++ b/e2e/cypress/e2e/07-invoices.cy.ts
@@ -35,7 +35,7 @@ describe('Invoices E2E', () => {
             cy.get('[data-cy="invoice-dialog"]').should('not.exist');
 
             // Click view button on the first invoice in the list
-            cy.get('button:has(svg.lucide-eye)').first().click();
+            cy.get('[data-cy="invoice-name"]').first().click();
             cy.get('[role="dialog"]').should('be.visible');
             cy.contains(/1[.,\s]?800/, { timeout: 10000 });
             cy.get('body').type('{esc}');
@@ -69,7 +69,7 @@ describe('Invoices E2E', () => {
 
             cy.get('[data-cy="invoice-dialog"]').should('not.exist');
 
-            cy.get('button:has(svg.lucide-eye)').first().click();
+            cy.get('[data-cy="invoice-name"]').first().click();
             cy.get('[role="dialog"]').should('be.visible');
             cy.contains(/6[.,\s]?600/, { timeout: 10000 });
             cy.get('body').type('{esc}');
@@ -163,7 +163,7 @@ describe('Invoices E2E', () => {
 
             cy.get('[data-cy="invoice-dialog"]').should('not.exist');
 
-            cy.get('button:has(svg.lucide-eye)').first().click();
+            cy.get('[data-cy="invoice-name"]').first().click();
             cy.get('[role="dialog"]').should('be.visible');
             cy.contains(/1[.,\s]?000/, { timeout: 10000 });
             cy.get('body').type('{esc}');
@@ -191,7 +191,7 @@ describe('Invoices E2E', () => {
 
             cy.get('[data-cy="invoice-dialog"]').should('not.exist');
 
-            cy.get('button:has(svg.lucide-eye)').first().click();
+            cy.get('[data-cy="invoice-name"]').first().click();
             cy.get('[role="dialog"]').should('be.visible');
             cy.contains(/299[.,]97/, { timeout: 10000 });
             cy.get('body').type('{esc}');
@@ -219,7 +219,7 @@ describe('Invoices E2E', () => {
 
             cy.get('[data-cy="invoice-dialog"]').should('not.exist');
 
-            cy.get('button:has(svg.lucide-eye)').first().click();
+            cy.get('[data-cy="invoice-name"]').first().click();
             cy.get('[role="dialog"]').should('be.visible');
             cy.contains(/600/, { timeout: 10000 });
             cy.get('body').type('{esc}');
@@ -231,7 +231,7 @@ describe('Invoices E2E', () => {
             cy.visit('/invoices');
             cy.wait(2000);
 
-            cy.get('button:has(svg.lucide-eye)').first().click();
+            cy.get('[data-cy="invoice-name"]').first().click();
 
             cy.get('[role="dialog"]').should('be.visible');
             // We can't be sure which invoice it is, but we can check if the dialog has content
@@ -279,7 +279,7 @@ describe('Invoices E2E', () => {
             cy.wait(2000);
 
             cy.contains('[data-cy="invoice-row"]', 'Jane Doe').within(() => {
-                cy.get('button:has(svg.lucide-eye)').click();
+                cy.get('[data-cy="invoice-name"]').click();
             });
             cy.get('[role="dialog"]').should('be.visible');
             cy.contains('Updated Notes');
@@ -335,7 +335,7 @@ describe('Invoices E2E', () => {
             cy.get('[data-cy="invoice-dialog"]').should('not.exist');
 
             // Verify the invoice displays the fractional quantity
-            cy.get('button:has(svg.lucide-eye)').first().click();
+            cy.get('[data-cy="invoice-name"]').first().click();
             cy.get('[role="dialog"]').should('be.visible');
             
             // Check that the total is calculated correctly (19.875 * 100 * 1.2 = 2385)
@@ -390,7 +390,7 @@ describe('Invoices E2E', () => {
             cy.get('[data-cy="invoice-dialog"]').should('not.exist');
 
             // Verify the total (0.25*800 + 2.75*1000 = 200 + 2750 = 2950 * 1.2 = 3540)
-            cy.get('button:has(svg.lucide-eye)').first().click();
+            cy.get('[data-cy="invoice-name"]').first().click();
             cy.get('[role="dialog"]').should('be.visible');
             cy.contains(/3[.,\s]?540/, { timeout: 10000 });
             cy.get('body').type('{esc}');

--- a/e2e/cypress/e2e/08-payments.cy.ts
+++ b/e2e/cypress/e2e/08-payments.cy.ts
@@ -3,34 +3,52 @@ beforeEach(() => {
 });
 
 // Draft and archived invoices can't receive a payment, so they aren't selectable in
-// the payment form. Create an invoice via the API and send it so it becomes SENT.
+// the payment form. Create an invoice via the UI and send it so it becomes SENT.
 function ensurePayableInvoice() {
-    cy.request('/api/clients?page=1').then(({ body }) => {
-        const clients = body.clients || [];
-        // Prefer a client with an email so /api/invoices/send actually flips the status to SENT.
-        const client = clients.find((c: any) => c.contactEmail) || clients[0];
-        expect(client, 'at least one client must exist').to.exist;
+    cy.visit('/invoices');
+    cy.contains('button', /add|new|créer|ajouter/i, { timeout: 10000 }).click();
+    cy.wait(500);
 
-        cy.request('POST', '/api/invoices', {
-            clientId: client.id,
-            notes: 'E2E payable invoice',
-            currency: 'EUR',
-            items: [{
-                description: 'Payable Service',
-                quantity: 1,
-                unitPrice: 200,
-                vatRate: 20,
-                type: 'SERVICE',
-                order: 0,
-            }],
-        }).then(({ body: invoice }) => {
-            expect(invoice.id, 'created invoice id').to.exist;
-            cy.request('POST', '/api/invoices/send', { id: invoice.id }).then(({ status }) => {
-                expect(status).to.be.oneOf([200, 201]);
-            });
-        });
+    cy.get('[data-cy="invoice-dialog"]', { timeout: 5000 }).should('be.visible');
+
+    cy.get('[data-cy="invoice-client-select"] button').first().click();
+    cy.wait(300);
+    cy.get('[data-cy="invoice-client-select-options"]').should('be.visible');
+    cy.get('[data-cy="invoice-client-select-options"] button').first().click();
+
+    cy.get('[data-cy="invoice-currency-select"] button').first().click();
+    cy.wait(200);
+    cy.get('[data-cy="invoice-currency-select"] input').type('EUR');
+    cy.wait(200);
+    cy.get('[data-cy="invoice-currency-select-option-euro-(€)"]').click();
+
+    cy.contains('button', /Add Item|Ajouter/i).click();
+    cy.get('[name="items.0.description"]').type('Payable Service', { force: true });
+    cy.get('[name="items.0.quantity"]').clear({ force: true }).type('1', { force: true });
+    cy.get('[name="items.0.unitPrice"]').clear({ force: true }).type('200', { force: true });
+    cy.get('[name="items.0.vatRate"]').clear({ force: true }).type('20', { force: true });
+
+    cy.get('[data-cy="invoice-submit"]').click();
+    cy.get('[data-cy="invoice-dialog"]').should('not.exist');
+    cy.wait(1000);
+
+    // Switch to the progression view and send the invoice so it becomes SENT (payable).
+    cy.get('[data-cy="invoice-view-progression"]').click();
+
+    cy.get('[data-cy="invoice-progression-row"]', { timeout: 10000 }).should('have.length.at.least', 1);
+    cy.get('[data-cy="invoice-progression-row"]').first().within(() => {
+        cy.get('[data-cy="invoice-progression-send"]').click();
     });
-    // Give the backend / React Query cache a moment to settle before the UI reads it.
+
+    cy.get('[role="alertdialog"]').should('be.visible').within(() => {
+        cy.get('[data-cy="invoice-progression-confirm-action"]').click();
+    });
+
+    // Wait until the row exposes the "Payment received" action, meaning the invoice is now SENT.
+    cy.get('[data-cy="invoice-progression-row"]').first().within(() => {
+        cy.get('[data-cy="invoice-progression-paymentReceived"]', { timeout: 15000 }).should('exist');
+    });
+
     cy.wait(500);
 }
 

--- a/e2e/cypress/e2e/08-payments.cy.ts
+++ b/e2e/cypress/e2e/08-payments.cy.ts
@@ -3,17 +3,35 @@ beforeEach(() => {
 });
 
 // Draft and archived invoices can't receive a payment, so they aren't selectable in
-// the payment form. Mark an invoice as paid first to make at least one selectable.
+// the payment form. Create an invoice via the API and send it so it becomes SENT.
 function ensurePayableInvoice() {
-    cy.visit('/invoices');
-    cy.wait(2000);
-    cy.get('body').then($body => {
-        const markButtons = $body.find('button:has(svg.lucide-banknote)');
-        if (markButtons.length > 0) {
-            cy.wrap(markButtons).first().click({ force: true });
-            cy.wait(1500);
-        }
+    cy.request('/api/clients?page=1').then(({ body }) => {
+        const clients = body.clients || [];
+        // Prefer a client with an email so /api/invoices/send actually flips the status to SENT.
+        const client = clients.find((c: any) => c.contactEmail) || clients[0];
+        expect(client, 'at least one client must exist').to.exist;
+
+        cy.request('POST', '/api/invoices', {
+            clientId: client.id,
+            notes: 'E2E payable invoice',
+            currency: 'EUR',
+            items: [{
+                description: 'Payable Service',
+                quantity: 1,
+                unitPrice: 200,
+                vatRate: 20,
+                type: 'SERVICE',
+                order: 0,
+            }],
+        }).then(({ body: invoice }) => {
+            expect(invoice.id, 'created invoice id').to.exist;
+            cy.request('POST', '/api/invoices/send', { id: invoice.id }).then(({ status }) => {
+                expect(status).to.be.oneOf([200, 201]);
+            });
+        });
     });
+    // Give the backend / React Query cache a moment to settle before the UI reads it.
+    cy.wait(500);
 }
 
 describe('Payments E2E', () => {

--- a/e2e/cypress/e2e/12-discount.cy.ts
+++ b/e2e/cypress/e2e/12-discount.cy.ts
@@ -103,22 +103,30 @@ function createInvoice({ discountRate = 10, item = defaultQuoteItem }: CreateInv
     });
 }
 
-function createPaymentForInvoice(invoiceLabel: string, invoiceId: string) {
+function createPaymentForInvoice(invoiceLabel: string) {
     cy.intercept('POST', '/api/payments/create-from-invoice').as('createPayment');
 
-    // The invoice is created as DRAFT; send it first so it becomes SENT and the
-    // "Payment received" action becomes available in the progression view.
-    cy.request('POST', '/api/invoices/send', { id: invoiceId }).then(({ status }) => {
-        expect(status).to.be.oneOf([200, 201]);
-    });
-
+    // The invoice is created as DRAFT; switch to the progression view, send it so it
+    // becomes SENT, then use the "Payment received" action to create the payment.
     cy.visit('/invoices');
     cy.get('[data-cy="invoice-view-progression"]').click();
 
     cy.contains('[data-cy="invoice-progression-row"]', invoiceLabel, { timeout: 20000 })
         .should('exist')
         .within(() => {
-            cy.get('[data-cy="invoice-progression-paymentReceived"]').click();
+            cy.get('[data-cy="invoice-progression-send"]').click();
+        });
+
+    cy.get('[role="alertdialog"]').should('be.visible').within(() => {
+        cy.get('[data-cy="invoice-progression-confirm-action"]').click();
+    });
+
+    // Wait until the row exposes the "Payment received" action (invoice is now SENT).
+    // Re-select by label to avoid a detached DOM node after the list re-renders.
+    cy.contains('[data-cy="invoice-progression-row"]', invoiceLabel, { timeout: 15000 })
+        .should('exist')
+        .within(() => {
+            cy.get('[data-cy="invoice-progression-paymentReceived"]').should('exist').click();
         });
 
     cy.get('[data-cy="payment-received-dialog"]', { timeout: 5000 }).should('be.visible');
@@ -241,8 +249,8 @@ describe('Discount Feature (Invoice)', () => {
 
 describe('Discount Feature (Payments)', () => {
     it('applies the configured discount rate to payment totals', () => {
-        createInvoice({ discountRate: 10 }).then(({ invoiceLabel, invoiceId }) => {
-            createPaymentForInvoice(invoiceLabel, invoiceId).then(() => {
+        createInvoice({ discountRate: 10 }).then(({ invoiceLabel }) => {
+            createPaymentForInvoice(invoiceLabel).then(() => {
                 cy.visit('/payments');
                 cy.contains('span', invoiceLabel, { timeout: 20000 })
                     .should('exist')

--- a/e2e/cypress/e2e/12-discount.cy.ts
+++ b/e2e/cypress/e2e/12-discount.cy.ts
@@ -103,20 +103,26 @@ function createInvoice({ discountRate = 10, item = defaultQuoteItem }: CreateInv
     });
 }
 
-function createPaymentForInvoice(invoiceLabel: string) {
+function createPaymentForInvoice(invoiceLabel: string, invoiceId: string) {
     cy.intercept('POST', '/api/payments/create-from-invoice').as('createPayment');
 
-    cy.contains('[data-cy="invoice-row"]', invoiceLabel, { timeout: 20000 })
-        .should('exist')
-        .closest('[data-cy="invoice-row"]')
-        .as('invoiceRow');
-
-    cy.get('@invoiceRow').within(() => {
-        cy.get('button')
-            .filter((_, el) => Cypress.$(el).find('svg.lucide-plus').length > 0)
-            .first()
-            .click({ force: true });
+    // The invoice is created as DRAFT; send it first so it becomes SENT and the
+    // "Payment received" action becomes available in the progression view.
+    cy.request('POST', '/api/invoices/send', { id: invoiceId }).then(({ status }) => {
+        expect(status).to.be.oneOf([200, 201]);
     });
+
+    cy.visit('/invoices');
+    cy.get('[data-cy="invoice-view-progression"]').click();
+
+    cy.contains('[data-cy="invoice-progression-row"]', invoiceLabel, { timeout: 20000 })
+        .should('exist')
+        .within(() => {
+            cy.get('[data-cy="invoice-progression-paymentReceived"]').click();
+        });
+
+    cy.get('[data-cy="payment-received-dialog"]', { timeout: 5000 }).should('be.visible');
+    cy.get('[data-cy="payment-received-submit"]').click();
 
     return cy.wait('@createPayment').then(({ response }) => {
         expect(response?.statusCode).to.be.oneOf([200, 201]);
@@ -235,8 +241,8 @@ describe('Discount Feature (Invoice)', () => {
 
 describe('Discount Feature (Payments)', () => {
     it('applies the configured discount rate to payment totals', () => {
-        createInvoice({ discountRate: 10 }).then(({ invoiceLabel }) => {
-            createPaymentForInvoice(invoiceLabel).then(() => {
+        createInvoice({ discountRate: 10 }).then(({ invoiceLabel, invoiceId }) => {
+            createPaymentForInvoice(invoiceLabel, invoiceId).then(() => {
                 cy.visit('/payments');
                 cy.contains('span', invoiceLabel, { timeout: 20000 })
                     .should('exist')

--- a/e2e/cypress/e2e/12-discount.cy.ts
+++ b/e2e/cypress/e2e/12-discount.cy.ts
@@ -219,7 +219,7 @@ describe('Discount Feature (Invoice)', () => {
                 .closest('[data-cy="invoice-row"]')
                 .as('invoiceRow');
 
-            cy.get('@invoiceRow').find('button:has(svg.lucide-eye)').first().click();
+            cy.get('@invoiceRow').find('[data-cy="invoice-name"]').first().click();
             cy.get('[role="dialog"]').should('be.visible').within(() => {
                 cy.contains('Discount Rate').parent().find('p.font-medium', { timeout: 10000 }).should('contain', '10%');
                 cy.contains('Discount Amount').parent().find('p.font-medium').should('contain', '100.00EUR');

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -438,7 +438,6 @@
                 "viewPdf": "PDF anzeigen",
                 "downloadPdf": "PDF herunterladen",
                 "edit": "Rechnung bearbeiten",
-                "markAsPaid": "Als bezahlt markieren",
                 "delete": "Rechnung löschen",
                 "createReceipt": "Erstelle ein Beleg von dieser Rechnung",
                 "sendByEmail": "Sende Rechnung per Email"

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -439,7 +439,6 @@
                 "downloadPdf": "PDF herunterladen",
                 "edit": "Rechnung bearbeiten",
                 "delete": "Rechnung löschen",
-                "createReceipt": "Erstelle ein Beleg von dieser Rechnung",
                 "sendByEmail": "Sende Rechnung per Email"
             },
             "actions": {
@@ -458,7 +457,6 @@
             "messages": {
                 "markAsPaidSuccess": "Rechnung als erfolgreich bezahlt markiert",
                 "markAsPaidError": "Rechnung konnte nicht als bezahlt markiert werden",
-                "createPaymentSuccess": "Zahlung erfolgreich aus Rechnung erstellt",
                 "sendByEmailSuccess": "Rechnung wurde versandt"
             }
         },

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -434,7 +434,7 @@
                 "totalTTC": "Gesamt (inkl. MwSt.)"
             },
             "tooltips": {
-                "viewPdf": "PDF anzeigen",
+                "exportPdf": "PDF exportieren",
                 "downloadPdf": "PDF herunterladen",
                 "edit": "Rechnung bearbeiten",
                 "delete": "Rechnung löschen",

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -434,7 +434,6 @@
                 "totalTTC": "Gesamt (inkl. MwSt.)"
             },
             "tooltips": {
-                "view": "Rechnungsdetails anzeigen",
                 "viewPdf": "PDF anzeigen",
                 "downloadPdf": "PDF herunterladen",
                 "edit": "Rechnung bearbeiten",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -502,7 +502,7 @@
                 "totalTTC": "Total (incl. VAT)"
             },
             "tooltips": {
-                "viewPdf": "View PDF",
+                "exportPdf": "Export PDF",
                 "downloadPdf": "Download PDF",
                 "edit": "Edit invoice",
                 "delete": "Delete invoice",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -502,7 +502,6 @@
                 "totalTTC": "Total (incl. VAT)"
             },
             "tooltips": {
-                "view": "View invoice details",
                 "viewPdf": "View PDF",
                 "downloadPdf": "Download PDF",
                 "edit": "Edit invoice",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -506,7 +506,6 @@
                 "viewPdf": "View PDF",
                 "downloadPdf": "Download PDF",
                 "edit": "Edit invoice",
-                "markAsPaid": "Mark as paid",
                 "delete": "Delete invoice",
                 "createPayment": "Create a payment from this invoice",
                 "sendByEmail": "Send invoice by email"

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -507,7 +507,6 @@
                 "downloadPdf": "Download PDF",
                 "edit": "Edit invoice",
                 "delete": "Delete invoice",
-                "createPayment": "Create a payment from this invoice",
                 "sendByEmail": "Send invoice by email"
             },
             "actions": {
@@ -526,7 +525,6 @@
             "messages": {
                 "markAsPaidSuccess": "Invoice marked as paid successfully",
                 "markAsPaidError": "Failed to mark invoice as paid",
-                "createPaymentSuccess": "Payment created successfully from invoice",
                 "sendByEmailSuccess": "Invoice has been sent to customer",
                 "archiveSuccess": "Invoice archived successfully",
                 "archiveError": "Failed to archive invoice"

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -438,7 +438,6 @@
                 "viewPdf": "Ver PDF",
                 "downloadPdf": "Descargar PDF",
                 "edit": "Editar factura",
-                "markAsPaid": "Marcar como pagada",
                 "delete": "Eliminar factura",
                 "createReceipt": "Crear recibo desde esta factura",
                 "sendByEmail": "Enviar factura por correo"

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -439,7 +439,6 @@
                 "downloadPdf": "Descargar PDF",
                 "edit": "Editar factura",
                 "delete": "Eliminar factura",
-                "createReceipt": "Crear recibo desde esta factura",
                 "sendByEmail": "Enviar factura por correo"
             },
             "actions": {
@@ -458,7 +457,6 @@
             "messages": {
                 "markAsPaidSuccess": "Factura marcada como pagada con éxito",
                 "markAsPaidError": "Error al marcar la factura como pagada",
-                "createPaymentSuccess": "Pago creado correctamente desde la factura",
                 "sendByEmailSuccess": "La factura fue enviada al cliente"
             }
         },

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -434,7 +434,7 @@
                 "totalTTC": "Total (con IVA)"
             },
             "tooltips": {
-                "viewPdf": "Ver PDF",
+                "exportPdf": "Exportar PDF",
                 "downloadPdf": "Descargar PDF",
                 "edit": "Editar factura",
                 "delete": "Eliminar factura",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -434,7 +434,6 @@
                 "totalTTC": "Total (con IVA)"
             },
             "tooltips": {
-                "view": "Ver detalles de la factura",
                 "viewPdf": "Ver PDF",
                 "downloadPdf": "Descargar PDF",
                 "edit": "Editar factura",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -503,7 +503,6 @@
                 "totalTTC": "Total TTC"
             },
             "tooltips": {
-                "view": "Voir les détails de la facture",
                 "viewPdf": "Voir le PDF",
                 "downloadPdf": "Télécharger le PDF",
                 "edit": "Modifier la facture",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -508,7 +508,6 @@
                 "downloadPdf": "Télécharger le PDF",
                 "edit": "Modifier la facture",
                 "delete": "Supprimer la facture",
-                "createPayment": "Créer un paiement à partir de cette facture",
                 "sendByEmail": "Envoyer la facture par email"
             },
             "actions": {
@@ -527,7 +526,6 @@
             "messages": {
                 "markAsPaidSuccess": "Facture marquée comme payée avec succès",
                 "markAsPaidError": "Échec du marquage de la facture comme payée",
-                "createPaymentSuccess": "Paiement créé avec succès à partir de la facture",
                 "sendByEmailSuccess": "La facture a été envoyée au client",
                 "archiveSuccess": "Facture archivée avec succès",
                 "archiveError": "Échec de l'archivage de la facture"

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -507,7 +507,6 @@
                 "viewPdf": "Voir le PDF",
                 "downloadPdf": "Télécharger le PDF",
                 "edit": "Modifier la facture",
-                "markAsPaid": "Marquer comme payée",
                 "delete": "Supprimer la facture",
                 "createPayment": "Créer un paiement à partir de cette facture",
                 "sendByEmail": "Envoyer la facture par email"

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -503,7 +503,7 @@
                 "totalTTC": "Total TTC"
             },
             "tooltips": {
-                "viewPdf": "Voir le PDF",
+                "exportPdf": "Exporter le PDF",
                 "downloadPdf": "Télécharger le PDF",
                 "edit": "Modifier la facture",
                 "delete": "Supprimer la facture",

--- a/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
@@ -1,8 +1,7 @@
-import { Code, Download, Edit, FileText, Mail, Plus, ReceiptText as PaymentText, Search, Trash2 } from "lucide-react"
+import { Edit, Mail, Plus, ReceiptText as PaymentText, Search, Trash2 } from "lucide-react"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
-import { forwardRef, useEffect, useImperativeHandle, useState } from "react"
-import { useGet, useGetRaw, usePost } from "@/hooks/use-fetch"
+import { forwardRef, useImperativeHandle, useState } from "react"
+import { usePost } from "@/hooks/use-fetch"
 
 import BetterPagination from "../../../../components/pagination"
 import { Badge } from "@/components/ui/badge"
@@ -41,18 +40,12 @@ export interface InvoiceListHandle {
     handleAddClick: () => void
 }
 
-interface PluginPdfFormat {
-    format_name: string
-    format_key: string
-}
-
 export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
     (
         { invoices, loading, title, description, searchTerm, onSearchChange, statusFilter, onStatusFilterChange, statusCounts, page, pageCount, setPage, mutate, emptyState, showCreateButton = false, onAddClick },
         ref,
     ) => {
         const { t } = useTranslation()
-        const { data: pdf_formats } = useGet<PluginPdfFormat[]>('/api/plugins/formats')
         const { trigger: triggerSendInvoiceByEmail, loading: sendInvoiceByEmailLoading } = usePost(`/api/invoices/send`)
 
         const [createInvoiceDialog, setCreateInvoiceDialog] = useState<boolean>(false)
@@ -61,42 +54,12 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
         const [viewInvoicePdfDialog, setViewInvoicePdfDialog] = useState<Invoice | null>(null)
         const [deleteInvoiceDialog, setDeleteInvoiceDialog] = useState<Invoice | null>(null)
         const [sendInvoiceDialog, setSendInvoiceDialog] = useState<Invoice | null>(null)
-        const [downloadTrigger, setDownloadTrigger] = useState<{
-            invoice: Invoice
-            format: string
-            file_format: 'pdf' | 'xml'
-            id: number
-        } | null>(null)
-
-        const { data: file } = useGetRaw<Response>(
-            downloadTrigger
-                ? `/api/invoices/${downloadTrigger.invoice.id}/download/${downloadTrigger.file_format}?format=${downloadTrigger.format}`
-                : null,
-        )
 
         useImperativeHandle(ref, () => ({
             handleAddClick() {
                 setCreateInvoiceDialog(true)
             },
         }))
-
-        useEffect(() => {
-            if (downloadTrigger && file) {
-                file.arrayBuffer().then((buffer) => {
-                    const blob = new Blob([buffer], { type: `application/${downloadTrigger.file_format}` })
-                    const url = URL.createObjectURL(blob)
-                    const link = document.createElement("a")
-                    link.href = url
-                    link.download = `invoice-${downloadTrigger.invoice.number}-${downloadTrigger.format}.${downloadTrigger.file_format}`
-                    document.body.appendChild(link)
-                    link.click()
-                    document.body.removeChild(link)
-                    URL.revokeObjectURL(url)
-                    setDownloadTrigger(null) // Reset
-                }).catch(() => {
-                })
-            }
-        }, [downloadTrigger, file])
 
         function handleEdit(invoice: Invoice) {
             setEditInvoiceDialog(invoice)
@@ -112,10 +75,6 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
 
         function handleDelete(invoice: Invoice) {
             setDeleteInvoiceDialog(invoice)
-        }
-
-        function handleDownload({ invoice, format, file_format }: { invoice: Invoice; format: string; file_format: 'pdf' | 'xml' }) {
-            setDownloadTrigger({ invoice, format, file_format, id: Date.now() })
         }
 
         const getStatusColor = (status: string) => {
@@ -337,7 +296,7 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                                             {invoice.status !== InvoiceStatus.UPCOMING && (
                                             <div className="grid grid-cols-2 lg:flex justify-start sm:justify-end gap-1 md:gap-2">
                                                 <Button
-                                                    tooltip={t("invoices.list.tooltips.viewPdf")}
+                                                    tooltip={t("invoices.list.tooltips.exportPdf")}
                                                     variant="ghost"
                                                     size="icon"
                                                     onClick={() => handleViewPdf(invoice)}
@@ -345,65 +304,6 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                                                 >
                                                     <PaymentText className="h-4 w-4" />
                                                 </Button>
-
-                                                <DropdownMenu>
-                                                    <DropdownMenuTrigger asChild>
-                                                        <Button
-                                                            tooltip={t("invoices.list.tooltips.downloadPdf")}
-                                                            variant="ghost"
-                                                            size="icon"
-                                                            className="text-gray-600 hover:text-amber-600"
-                                                        >
-                                                            <Download className="h-4 w-4" />
-                                                        </Button>
-                                                    </DropdownMenuTrigger>
-                                                    <DropdownMenuContent align="center" className="[&>*]:cursor-pointer w-48">
-                                                        <DropdownMenuLabel className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
-                                                            <FileText className="h-3 w-3" />
-                                                            {t("invoices.list.actions.downloadPdf")}
-                                                        </DropdownMenuLabel>
-
-                                                        <DropdownMenuItem onClick={() => handleDownload({ invoice, format: "", file_format: "pdf" })}>Standard</DropdownMenuItem>
-                                                        <DropdownMenuItem onClick={() => handleDownload({ invoice, format: "facturx", file_format: "pdf" })}>Factur-X</DropdownMenuItem>
-                                                        <DropdownMenuItem onClick={() => handleDownload({ invoice, format: "zugferd", file_format: "pdf" })}>ZUGFeRD</DropdownMenuItem>
-                                                        <DropdownMenuItem onClick={() => handleDownload({ invoice, format: "xrechnung", file_format: "pdf" })}>
-                                                            XRechnung
-                                                        </DropdownMenuItem>
-                                                        <DropdownMenuItem onClick={() => handleDownload({ invoice, format: "ubl", file_format: "pdf" })}>UBL</DropdownMenuItem>
-                                                        <DropdownMenuItem onClick={() => handleDownload({ invoice, format: "cii", file_format: "pdf" })}>CII</DropdownMenuItem>
-
-                                                        <DropdownMenuSeparator />
-
-                                                        <DropdownMenuLabel className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
-                                                            <Code className="h-3 w-3" />
-                                                            {t("invoices.list.actions.downloadXml")}
-                                                        </DropdownMenuLabel>
-
-                                                        <DropdownMenuItem onClick={() => handleDownload({ invoice, format: "facturx", file_format: "xml" })}>
-                                                            Factur-X
-                                                        </DropdownMenuItem>
-                                                        <DropdownMenuItem onClick={() => handleDownload({ invoice, format: "zugferd", file_format: "xml" })}>
-                                                            ZUGFeRD
-                                                        </DropdownMenuItem>
-                                                        <DropdownMenuItem onClick={() => handleDownload({ invoice, format: "xrechnung", file_format: "xml" })}>
-                                                            XRechnung
-                                                        </DropdownMenuItem>
-                                                        <DropdownMenuItem onClick={() => handleDownload({ invoice, format: "ubl", file_format: "xml" })}>
-                                                            UBL
-                                                        </DropdownMenuItem>
-                                                        <DropdownMenuItem onClick={() => handleDownload({ invoice, format: "cii", file_format: "xml" })}>
-                                                            CII
-                                                        </DropdownMenuItem>
-                                                        {pdf_formats?.map((format) => (
-                                                            <DropdownMenuItem
-                                                                key={format.format_key}
-                                                                onClick={() => handleDownload({ invoice, format: format.format_key, file_format: "xml" })}
-                                                            >
-                                                                {format.format_name}
-                                                            </DropdownMenuItem>
-                                                        ))}
-                                                    </DropdownMenuContent>
-                                                </DropdownMenu>
 
                                                 {invoice.status !== "PAID" && (
                                                     <Button

--- a/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
@@ -430,7 +430,7 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                                                     </Button>
                                                 )}
 
-                                                {invoice.status !== "PAID" && invoice.status !== "OVERDUE" && (
+                                                {invoice.status === InvoiceStatus.DRAFT && (
                                                     <Button
                                                         tooltip={t("invoices.list.tooltips.delete")}
                                                         variant="ghost"

--- a/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
@@ -305,7 +305,7 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                                                     <PaymentText className="h-4 w-4" />
                                                 </Button>
 
-                                                {invoice.status !== "PAID" && (
+                                                {invoice.status === InvoiceStatus.DRAFT && (
                                                     <Button
                                                         data-cy="invoice-edit-button"
                                                         tooltip={t("invoices.list.tooltips.edit")}

--- a/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
@@ -1,4 +1,4 @@
-import { Code, Download, Edit, Eye, FileText, Mail, Plus, ReceiptText as PaymentText, Search, Trash2 } from "lucide-react"
+import { Code, Download, Edit, FileText, Mail, Plus, ReceiptText as PaymentText, Search, Trash2 } from "lucide-react"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react"
@@ -259,14 +259,23 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                                                 <div className="flex-1">
                                                     <div className="flex flex-wrap items-center gap-2">
                                                         <h3 className="font-medium text-foreground break-words">
-                                                            {invoice.status === InvoiceStatus.UPCOMING
-                                                                ? t("invoices.list.item.upcomingTitle", {
+                                                            {invoice.status === InvoiceStatus.UPCOMING ? (
+                                                                t("invoices.list.item.upcomingTitle", {
                                                                     client: invoice.client.name || `${invoice.client.contactFirstname} ${invoice.client.contactLastname}`,
                                                                 })
-                                                                : t("invoices.list.item.title", {
-                                                                    number: invoice.rawNumber || invoice.number,
-                                                                    title: invoice.title,
-                                                                })}
+                                                            ) : (
+                                                                <button
+                                                                    type="button"
+                                                                    onClick={() => handleView(invoice)}
+                                                                    className="underline hover:text-primary text-left"
+                                                                    data-cy="invoice-name"
+                                                                >
+                                                                    {t("invoices.list.item.title", {
+                                                                        number: invoice.rawNumber || invoice.number,
+                                                                        title: invoice.title,
+                                                                    })}
+                                                                </button>
+                                                            )}
                                                         </h3>
                                                         <span
                                                             data-cy="invoice-status"
@@ -327,16 +336,6 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
 
                                             {invoice.status !== InvoiceStatus.UPCOMING && (
                                             <div className="grid grid-cols-2 lg:flex justify-start sm:justify-end gap-1 md:gap-2">
-                                                <Button
-                                                    tooltip={t("invoices.list.tooltips.view")}
-                                                    variant="ghost"
-                                                    size="icon"
-                                                    onClick={() => handleView(invoice)}
-                                                    className="text-gray-600 hover:text-blue-600"
-                                                >
-                                                    <Eye className="h-4 w-4" />
-                                                </Button>
-
                                                 <Button
                                                     tooltip={t("invoices.list.tooltips.viewPdf")}
                                                     variant="ghost"

--- a/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
@@ -1,4 +1,4 @@
-import { Banknote, Code, Download, Edit, Eye, FileText, Mail, Plus, ReceiptText as PaymentText, Search, Trash2 } from "lucide-react"
+import { Code, Download, Edit, Eye, FileText, Mail, Plus, ReceiptText as PaymentText, Search, Trash2 } from "lucide-react"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react"
@@ -56,7 +56,6 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
         const { t } = useTranslation()
         const queryClient = useQueryClient()
         const { data: pdf_formats } = useGet<PluginPdfFormat[]>('/api/plugins/formats')
-        const { trigger: triggerMarkAsPaid } = usePost(`/api/invoices/mark-as-paid`)
         const { trigger: triggerSendInvoiceByEmail, loading: sendInvoiceByEmailLoading } = usePost(`/api/invoices/send`)
         const { trigger: triggerCreatePayment } = usePost(`/api/payments/create-from-invoice`)
 
@@ -117,18 +116,6 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
 
         function handleDelete(invoice: Invoice) {
             setDeleteInvoiceDialog(invoice)
-        }
-
-        function handleMarkAsPaid(invoiceId: string) {
-            triggerMarkAsPaid({ invoiceId })
-                .then(() => {
-                    toast.success(t("invoices.list.messages.markAsPaidSuccess"))
-                    queryClient.invalidateQueries({ queryKey: queryKeys.invoices.listsAll() })
-                })
-                .catch((error) => {
-                    console.error("Error marking invoice as paid:", error)
-                    toast.error(t("invoices.list.messages.markAsPaidError"))
-                })
         }
 
         function handleDownload({ invoice, format, file_format }: { invoice: Invoice; format: string; file_format: 'pdf' | 'xml' }) {
@@ -458,18 +445,6 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                                                         className="text-gray-600 hover:text-purple-600"
                                                     >
                                                         <Mail className="h-4 w-4" />
-                                                    </Button>
-                                                )}
-
-                                                {invoice.status !== "PAID" && (
-                                                    <Button
-                                                        tooltip={t("invoices.list.tooltips.markAsPaid")}
-                                                        variant="ghost"
-                                                        size="icon"
-                                                        onClick={() => handleMarkAsPaid(invoice.id)}
-                                                        className="text-gray-600 hover:text-blue-600"
-                                                    >
-                                                        <Banknote className="h-4 w-4" />
                                                     </Button>
                                                 )}
 

--- a/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
@@ -3,8 +3,6 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react"
 import { useGet, useGetRaw, usePost } from "@/hooks/use-fetch"
-import { queryKeys } from "@/lib/query-keys"
-import { useQueryClient } from "@tanstack/react-query"
 
 import BetterPagination from "../../../../components/pagination"
 import { Badge } from "@/components/ui/badge"
@@ -54,10 +52,8 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
         ref,
     ) => {
         const { t } = useTranslation()
-        const queryClient = useQueryClient()
         const { data: pdf_formats } = useGet<PluginPdfFormat[]>('/api/plugins/formats')
         const { trigger: triggerSendInvoiceByEmail, loading: sendInvoiceByEmailLoading } = usePost(`/api/invoices/send`)
-        const { trigger: triggerCreatePayment } = usePost(`/api/payments/create-from-invoice`)
 
         const [createInvoiceDialog, setCreateInvoiceDialog] = useState<boolean>(false)
         const [editInvoiceDialog, setEditInvoiceDialog] = useState<Invoice | null>(null)
@@ -120,19 +116,6 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
 
         function handleDownload({ invoice, format, file_format }: { invoice: Invoice; format: string; file_format: 'pdf' | 'xml' }) {
             setDownloadTrigger({ invoice, format, file_format, id: Date.now() })
-        }
-
-        function handleCreatePaymentFromInvoice(invoiceId: string) {
-            triggerCreatePayment({ id: invoiceId })
-                .then(() => {
-                    toast.success(t("invoices.list.messages.createPaymentSuccess"))
-                    queryClient.invalidateQueries({ queryKey: queryKeys.payments.listsAll() })
-                    queryClient.invalidateQueries({ queryKey: queryKeys.invoices.listsAll() })
-                })
-                .catch((error) => {
-                    console.error("Error creating payment from invoice:", error)
-                    toast.error(t("invoices.list.messages.createPaymentError"))
-                })
         }
 
         const getStatusColor = (status: string) => {
@@ -461,15 +444,6 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                                                     </Button>
                                                 )}
 
-                                                <Button
-                                                    tooltip={t("invoices.list.tooltips.createPayment")}
-                                                    variant="ghost"
-                                                    size="icon"
-                                                    onClick={() => handleCreatePaymentFromInvoice(invoice.id)}
-                                                    className="text-gray-600 hover:text-green-600"
-                                                >
-                                                    <Plus className="h-4 w-4" />
-                                                </Button>
                                             </div>
                                             )}
                                         </div>

--- a/frontend/src/pages/(app)/invoices/_components/invoice-pdf-view.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-pdf-view.tsx
@@ -1,8 +1,11 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { useEffect, useState } from "react"
+import { useGet, useGetRaw } from "@/hooks/use-fetch"
 
+import { Button } from "@/components/ui/button"
+import { Code, Download, FileText } from "lucide-react"
 import type { Invoice } from "@/types"
-import { useGetRaw } from "@/hooks/use-fetch"
 import { useTranslation } from "react-i18next"
 
 type InvoicePdfModalProps = {
@@ -10,10 +13,28 @@ type InvoicePdfModalProps = {
   onOpenChange: (open: boolean) => void
 }
 
+interface PluginPdfFormat {
+  format_name: string
+  format_key: string
+}
+
 export function InvoicePdfModal({ invoice, onOpenChange }: InvoicePdfModalProps) {
   const { t } = useTranslation()
   const { data } = useGetRaw<Response>(invoice ? `/api/invoices/${invoice.id}/pdf` : null)
   const [pdfData, setPdfData] = useState<Uint8Array | null>(null)
+
+  const { data: pdf_formats } = useGet<PluginPdfFormat[]>('/api/plugins/formats')
+  const [downloadTrigger, setDownloadTrigger] = useState<{
+    format: string
+    file_format: 'pdf' | 'xml'
+    id: number
+  } | null>(null)
+
+  const { data: file } = useGetRaw<Response>(
+    downloadTrigger && invoice
+      ? `/api/invoices/${invoice.id}/download/${downloadTrigger.file_format}?format=${downloadTrigger.format}`
+      : null,
+  )
 
   useEffect(() => {
     if (data) {
@@ -23,7 +44,30 @@ export function InvoicePdfModal({ invoice, onOpenChange }: InvoicePdfModalProps)
     }
   }, [data])
 
+  useEffect(() => {
+    if (downloadTrigger && file && invoice) {
+      file.arrayBuffer().then((buffer) => {
+        const blob = new Blob([buffer], { type: `application/${downloadTrigger.file_format}` })
+        const url = URL.createObjectURL(blob)
+        const link = document.createElement("a")
+        link.href = url
+        link.download = `invoice-${invoice.number}-${downloadTrigger.format}.${downloadTrigger.file_format}`
+        document.body.appendChild(link)
+        link.click()
+        document.body.removeChild(link)
+        URL.revokeObjectURL(url)
+        setDownloadTrigger(null)
+      }).catch(() => { })
+    }
+  }, [downloadTrigger, file, invoice])
+
   if (!invoice) return null
+
+  const pdfBase64 = pdfData ? btoa(String.fromCharCode(...pdfData)) : null
+
+  const handleDownload = ({ format, file_format }: { format: string; file_format: 'pdf' | 'xml' }) => {
+    setDownloadTrigger({ format, file_format, id: Date.now() })
+  }
 
   return (
     <Dialog
@@ -31,20 +75,63 @@ export function InvoicePdfModal({ invoice, onOpenChange }: InvoicePdfModalProps)
       onOpenChange={(open) => {
         if (!open) {
           setPdfData(null)
+          setDownloadTrigger(null)
         }
         onOpenChange(open)
       }}
     >
       <DialogContent className="!max-w-6xl w-[95vw] h-[90dvh] overflow-hidden flex flex-col">
-        <DialogHeader>
+        <DialogHeader className="flex flex-row items-center justify-between gap-4 pr-8">
           <DialogTitle>{t("invoices.pdf.title", { number: invoice?.number })}</DialogTitle>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button type="button" variant="outline" size="sm">
+                <Download className="h-4 w-4 mr-2" />
+                {t("invoices.list.tooltips.downloadPdf")}
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="[&>*]:cursor-pointer w-48">
+              <DropdownMenuLabel className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+                <FileText className="h-3 w-3" />
+                {t("invoices.list.actions.downloadPdf")}
+              </DropdownMenuLabel>
+
+              <DropdownMenuItem onClick={() => handleDownload({ format: "", file_format: "pdf" })}>Standard</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => handleDownload({ format: "facturx", file_format: "pdf" })}>Factur-X</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => handleDownload({ format: "zugferd", file_format: "pdf" })}>ZUGFeRD</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => handleDownload({ format: "xrechnung", file_format: "pdf" })}>XRechnung</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => handleDownload({ format: "ubl", file_format: "pdf" })}>UBL</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => handleDownload({ format: "cii", file_format: "pdf" })}>CII</DropdownMenuItem>
+
+              <DropdownMenuSeparator />
+
+              <DropdownMenuLabel className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+                <Code className="h-3 w-3" />
+                {t("invoices.list.actions.downloadXml")}
+              </DropdownMenuLabel>
+
+              <DropdownMenuItem onClick={() => handleDownload({ format: "facturx", file_format: "xml" })}>Factur-X</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => handleDownload({ format: "zugferd", file_format: "xml" })}>ZUGFeRD</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => handleDownload({ format: "xrechnung", file_format: "xml" })}>XRechnung</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => handleDownload({ format: "ubl", file_format: "xml" })}>UBL</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => handleDownload({ format: "cii", file_format: "xml" })}>CII</DropdownMenuItem>
+              {pdf_formats?.map((format) => (
+                <DropdownMenuItem
+                  key={format.format_key}
+                  onClick={() => handleDownload({ format: format.format_key, file_format: "xml" })}
+                >
+                  {format.format_name}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </DialogHeader>
         <section className="h-full overflow-auto">
-          {pdfData ? (
+          {pdfBase64 ? (
             <div className="flex justify-center h-full overflow-auto">
               <iframe
                 className="w-full h-full"
-                src={`data:application/pdf;base64,${btoa(String.fromCharCode(...pdfData))}`}
+                src={`data:application/pdf;base64,${pdfBase64}#zoom=page-fit`}
                 title={t("invoices.pdf.title", { number: invoice?.number })}
               />
             </div>

--- a/frontend/src/pages/(app)/invoices/_components/invoice-progression.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-progression.tsx
@@ -291,7 +291,7 @@ export function InvoiceProgression({
                         <AlertDialogCancel onClick={() => setConfirmDialog(null)}>
                             {t("invoices.progression.confirmations.cancel")}
                         </AlertDialogCancel>
-                        <AlertDialogAction onClick={handleConfirm}>
+                        <AlertDialogAction data-cy="invoice-progression-confirm-action" onClick={handleConfirm}>
                             {t("invoices.progression.confirmations.confirm")}
                         </AlertDialogAction>
                     </AlertDialogFooter>

--- a/frontend/src/pages/(app)/invoices/_components/invoice-progression.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-progression.tsx
@@ -177,6 +177,7 @@ export function InvoiceProgression({
                             return (
                                 <div
                                     key={invoice.id}
+                                    data-cy="invoice-progression-row"
                                     className="py-4 sm:py-5 px-4 sm:px-8 lg:px-12 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
                                 >
                                     <div className="min-w-0 sm:w-44 sm:flex-shrink-0">
@@ -233,6 +234,7 @@ export function InvoiceProgression({
                                                     key={action.action}
                                                     variant={index === actions.length - 1 ? "default" : "outline"}
                                                     size="sm"
+                                                    dataCy={`invoice-progression-${action.action}`}
                                                     className={cn(
                                                         "h-8 text-xs px-3 whitespace-nowrap",
                                                         index === actions.length - 1 &&

--- a/frontend/src/pages/(app)/invoices/_components/invoice-view.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-view.tsx
@@ -28,7 +28,7 @@ export function InvoiceViewDialog({ invoice, onOpenChange }: InvoiceViewDialogPr
 
     return (
         <Dialog open={!!invoice} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-[95vw] lg:max-w-3xl max-h-[90dvh] flex flex-col relative overflow-hidden">
+            <DialogContent className="max-w-[95vw] lg:max-w-3xl max-h-[90dvh] flex flex-col overflow-hidden">
                 {invoice.status === "DRAFT" && (
                     <div className="pointer-events-none absolute inset-0 flex items-center justify-center z-50 overflow-hidden">
                         <span className="text-8xl font-bold text-red-500/15 -rotate-[30deg] select-none whitespace-nowrap">


### PR DESCRIPTION
## Summary

Cleans up the invoice actions so that paid status only ever results from real
payments, deletion is restricted to drafts, and PDF viewing/exporting is
consolidated into a single modal.

## Changes

### Invoice status is payment-driven
- Removed the "mark as paid" action (backend `POST /api/invoices/mark-as-paid`
  + `markInvoiceAsPaid`, and the list button). An invoice can no longer be
  flipped to PAID without an actual payment.
- Removed the "create a payment from this invoice" one-click button from the
  list. The backend `create-from-invoice` endpoint stays — it still backs the
  "Payment received" dialog and the deprecated receipts alias.

### Deletion restricted to drafts
- Only `DRAFT` invoices can be deleted: backend rejects any non-draft with a
  400, and the delete button only renders for drafts.

### Invoice detail & PDF export UX
- The invoice detail dialog now opens by clicking the invoice's name (rendered
  as an underlined link); the separate "view details" (eye) button was removed.
- Re-centered the invoice detail dialog (the DRAFT watermark's `relative` class
  was overriding the dialog's `fixed` positioning).
- The PDF modal is now the single export entry point: it previews the document
  at page-fit zoom and offers the full format list (PDF Standard / Factur-X /
  ZUGFeRD / XRechnung / UBL / CII + XML and plugin formats). The standalone
  "download PDF" dropdown was removed from the list and the PDF button was
  relabeled "Export PDF".

### i18n
- Updated EN/FR/DE/ES locales accordingly (renamed/removed orphaned keys for
  the affected tooltips, actions, and messages).

## Tests
- Updated e2e specs (`07-invoices`, `12-discount`) to open the detail dialog via
  the invoice name instead of the removed eye button.
- Backend `tsc` + jest, frontend `tsc -b` + `vite build` all pass.